### PR TITLE
IPFS banner/thumbnail upload functionality

### DIFF
--- a/vue-app/src/api/recipient-registry-optimistic.ts
+++ b/vue-app/src/api/recipient-registry-optimistic.ts
@@ -81,7 +81,6 @@ export interface RecipientApplicationData {
     discord: string;
   };
   image: {
-    requiresUpload: '' | 'true' | 'false';
     bannerHash: string;
     thumbnailHash: string;
     banner: ImageState;

--- a/vue-app/src/api/recipient-registry-optimistic.ts
+++ b/vue-app/src/api/recipient-registry-optimistic.ts
@@ -46,16 +46,6 @@ export enum RequestStatus {
   Executed = 'Executed',
 }
 
-interface ImageState {
-  hash: string;
-  success: string;
-  failure: string;
-  // modalOpen: boolean;
-  document: string;
-  loading: boolean;
-  data: string;
-}
-
 export interface RecipientApplicationData {
   project: {
     name: string;
@@ -83,8 +73,6 @@ export interface RecipientApplicationData {
   image: {
     bannerHash: string;
     thumbnailHash: string;
-    banner: ImageState;
-    thumbnail: ImageState;
   };
   furthestStep: number;
 }

--- a/vue-app/src/api/recipient-registry-optimistic.ts
+++ b/vue-app/src/api/recipient-registry-optimistic.ts
@@ -53,6 +53,7 @@ interface ImageState {
   // modalOpen: boolean;
   document: string;
   loading: boolean;
+  data: string;
 }
 
 export interface RecipientApplicationData {

--- a/vue-app/src/components/IpfsForm.vue
+++ b/vue-app/src/components/IpfsForm.vue
@@ -1,0 +1,121 @@
+<template>
+  <form method="POST" enctype="multipart/form-data" @submit="handleUploadToIPFS" name="banner">
+    <p class="input-label">{{ label }}</p>
+    <p class="input-description"> {{description}} </p>
+    <input
+      id="image-banner-upload"
+      type="file"
+      class="input"
+      @change="handleLoadFile"
+      name="banner"
+    />
+    <button primary="true" type='submit' label='Upload' class="btn-primary upload-btn">
+      {{ loading ? "Loading..." : "Upload"}}
+    </button>
+    <div class="image-preview">
+      <loader v-if="loading" />
+      <img
+        v-if="data"
+        :src="data"
+        alt=""
+        :class="{
+          'image-preview': data,
+        }"
+      />
+      <p v-if="data">IPFS hash: {{ hash }}</p>
+    </div>
+  </form>
+</template>
+
+<script lang="ts">
+import Vue from 'vue'
+import Component from 'vue-class-component'
+import { Prop } from 'vue-property-decorator'
+
+import Loader from '@/components/Loader.vue'
+
+import IPFS from 'ipfs-mini'
+
+@Component({
+  components: { Loader },
+})
+export default class IpfsForm extends Vue {
+
+  @Prop()
+  label!: string
+
+  @Prop()
+  description!: string
+ 
+  @Prop()
+  formProp!: string
+
+  @Prop()
+  onUpload!: (key: string, value: string) => void
+
+  hash: string | null
+  loading = false
+  data: string | null = null
+  document: string | null
+  error: string | null
+  ipfs: any = null
+
+  created() {
+    this.ipfs = new IPFS({ host: 'ipfs.infura.io', port: 5001, protocol: 'https' })
+  }
+
+  // TODO raise error if not valid image (JPG / PNG / GIF)
+  handleLoadFile(event) {
+    const data = event.target.files[0]
+    console.log(data)
+    if (data.type.match('image/*')) {
+      const reader = new FileReader()
+      reader.onload = (() => ((e) => {this.document = e.target.result}))()
+      reader.readAsDataURL(data)
+    } else {
+      this.error = 'That doesn\'t look like an image'
+    }
+  }
+
+  // TODO display error in UI
+  handleUploadToIPFS(event) {
+    event.preventDefault()
+
+    if (this.document !== '') {
+      this.loading = true
+      this.ipfs.addJSON(this.document, async (err, _hash) => {
+        if (!err) {
+          this.hash = _hash
+          this.ipfs.catJSON(this.hash, async (err2, data) => {
+            if (!err2) {
+              this.data = data
+              this.onUpload(this.formProp, this.hash)
+
+            } else {
+              this.error = `Error occured: ${err2.message}`
+            }
+            this.loading = false
+          })
+        } else {
+          this.loading = false
+          this.error = 'Error occured: ${err.message}'
+        }
+      })
+    } else {
+      this.error = 'You need an image.'
+    }
+  }
+
+}
+</script>
+
+<style scoped lang="scss">
+@import "../styles/vars";
+@import "../styles/theme";
+
+  .image-preview {
+    width: 500px;
+    height: auto;
+  }
+
+</style>

--- a/vue-app/src/components/IpfsForm.vue
+++ b/vue-app/src/components/IpfsForm.vue
@@ -1,17 +1,19 @@
 <template>
-  <form method="POST" enctype="multipart/form-data" @submit="handleUploadToIPFS" name="banner">
+  <form method="POST" enctype="multipart/form-data" @submit="handleUploadToIPFS" name="image">
     <p class="input-label">{{ label }}</p>
     <p class="input-description"> {{description}} </p>
-    <input
-      id="image-banner-upload"
-      type="file"
-      class="input"
-      @change="handleLoadFile"
-      name="banner"
-    />
-    <button primary="true" type='submit' label='Upload' class="btn-primary upload-btn" :class="{disabled: loading || error || !document}">
-      {{ loading ? "Loading..." : "Upload"}}
-    </button>
+    <div class="input-row">
+      <input
+        id="image-upload"
+        type="file"
+        class="input"
+        @change="handleLoadFile"
+        name="image"
+      />
+      <button primary="true" type='submit' label='Upload' class="btn-primary" :class="{disabled: loading || error || !document}">
+        {{ loading ? "Loading..." : "Upload"}}
+      </button>
+    </div>
     <div class="image-preview">
       <loader v-if="loading" />
       <img
@@ -25,6 +27,7 @@
       <p v-if="data">IPFS hash: {{ hash }}</p>
       <p v-if="error" class="error">{{ error }}</p>
     </div>
+    <div @click="handleRemoveImage" class="btn-white small">Clear</div>
   </form>
 </template>
 
@@ -98,6 +101,15 @@ export default class IpfsForm extends Vue {
       this.error = 'You need an image.'
     }
   }
+
+  handleRemoveImage(): void {
+    this.hash = ''
+    this.loading = false
+    this.data = ''
+    this.document = ''
+    this.error = ''
+    this.onUpload(this.formProp, '')
+  }
 }
 </script>
 
@@ -119,5 +131,23 @@ export default class IpfsForm extends Vue {
     transform: scale(1);
     cursor: not-allowed;
   }  
+}
+
+.btn-white.small {
+  max-width: calc(5ch + 4rem);
+}
+
+.input-row {
+  display: flex;
+  gap: 1rem;
+  @media (max-width: $breakpoint-m) {
+    flex-direction: column;
+  }
+  margin: 1rem 0 2rem;
+}
+
+.input {
+  flex: 1;
+  margin: 0;
 }
 </style>

--- a/vue-app/src/components/IpfsForm.vue
+++ b/vue-app/src/components/IpfsForm.vue
@@ -24,7 +24,7 @@
           'image-preview': data,
         }"
       />
-      <p v-if="data">IPFS hash: {{ hash }}</p>
+      <p v-if="data" @click="copyHash" class="copy">IPFS hash: {{ hash }} 📋</p>
       <p v-if="error" class="error">{{ error }}</p>
     </div>
     <div @click="handleRemoveImage" class="btn-white small">Clear</div>
@@ -110,6 +110,15 @@ export default class IpfsForm extends Vue {
     this.error = ''
     this.onUpload(this.formProp, '')
   }
+
+  async copyHash(): Promise<void> {
+    try {
+      await navigator.clipboard.writeText(this.hash)
+      // TODO: UX success feedback
+    } catch (error) {
+      console.warn('Error in copying text: ', error) /* eslint-disable-line no-console */
+    }
+  }
 }
 </script>
 
@@ -149,5 +158,9 @@ export default class IpfsForm extends Vue {
 .input {
   flex: 1;
   margin: 0;
+}
+
+.copy {
+  cursor: pointer;
 }
 </style>

--- a/vue-app/src/components/IpfsForm.vue
+++ b/vue-app/src/components/IpfsForm.vue
@@ -9,7 +9,7 @@
       @change="handleLoadFile"
       name="banner"
     />
-    <button primary="true" type='submit' label='Upload' class="btn-primary upload-btn">
+    <button primary="true" type='submit' label='Upload' class="btn-primary upload-btn" :class="{disabled: loading || error || !document}">
       {{ loading ? "Loading..." : "Upload"}}
     </button>
     <div class="image-preview">
@@ -23,6 +23,7 @@
         }"
       />
       <p v-if="data">IPFS hash: {{ hash }}</p>
+      <p v-if="error" class="error">{{ error }}</p>
     </div>
   </form>
 </template>
@@ -40,24 +41,16 @@ import IPFS from 'ipfs-mini'
   components: { Loader },
 })
 export default class IpfsForm extends Vue {
+  @Prop() label!: string
+  @Prop() description!: string
+  @Prop() formProp!: string
+  @Prop() onUpload!: (key: string, value: string) => void
 
-  @Prop()
-  label!: string
-
-  @Prop()
-  description!: string
- 
-  @Prop()
-  formProp!: string
-
-  @Prop()
-  onUpload!: (key: string, value: string) => void
-
-  hash: string | null
+  hash = ''
   loading = false
-  data: string | null = null
-  document: string | null
-  error: string | null
+  data = ''
+  document = ''
+  error = ''
   ipfs: any = null
 
   created() {
@@ -66,8 +59,8 @@ export default class IpfsForm extends Vue {
 
   // TODO raise error if not valid image (JPG / PNG / GIF)
   handleLoadFile(event) {
+    this.error = ''
     const data = event.target.files[0]
-    console.log(data)
     if (data.type.match('image/*')) {
       const reader = new FileReader()
       reader.onload = (() => ((e) => {this.document = e.target.result}))()
@@ -105,7 +98,6 @@ export default class IpfsForm extends Vue {
       this.error = 'You need an image.'
     }
   }
-
 }
 </script>
 
@@ -113,9 +105,19 @@ export default class IpfsForm extends Vue {
 @import "../styles/vars";
 @import "../styles/theme";
 
-  .image-preview {
-    width: 500px;
-    height: auto;
-  }
+.image-preview {
+  width: 500px;
+  height: auto;
+}
 
+.disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+
+  &:hover {
+    opacity: 0.5;
+    transform: scale(1);
+    cursor: not-allowed;
+  }  
+}
 </style>

--- a/vue-app/src/views/Join.vue
+++ b/vue-app/src/views/Join.vue
@@ -698,7 +698,6 @@ export default class JoinView extends mixins(validationMixin) {
           this.ipfs.catJSON(this.form.image[name].hash, async (err2, data) => {
             if(!err2) {
               this.form.image[name].data = data
-              console.log({data})
             } else {
               // this.form.image[name].modalOpen = true
               this.form.image[name].failure = `Error occured: ${err.message}`

--- a/vue-app/src/views/Join.vue
+++ b/vue-app/src/views/Join.vue
@@ -585,7 +585,7 @@ export default class JoinView extends mixins(validationMixin) {
 } 
 </script>
 
-<style scoped lang="scss">
+<style lang="scss">
 @import "../styles/vars";
 @import "../styles/theme";
 

--- a/vue-app/src/views/Join.vue
+++ b/vue-app/src/views/Join.vue
@@ -929,38 +929,6 @@ export default class JoinView extends mixins(validationMixin) {
   }
 }
 
-/* #uploadRadio {
-  input {
-    margin-right: 0.5rem;
-  }
-} */
-
-.upload-btn {
-  margin-left: 1rem;
-}
-
-.image-preview {
-  display: flex;
-  flex-direction: column;
-  margin-top: 1rem;
-
-  .banner-image {
-    width: 500px;
-    height: auto;
-  }
-
-  .thumbnail-image {
-    width: 80px;
-    height: auto;
-  }
-
-  .spacer {
-    border: 1px solid #000;
-    border-radius: 0.5rem;
-    padding: 1rem;
-  }
-}
-
 .loader {
   display: block;
   height: 40px;

--- a/vue-app/src/views/Join.vue
+++ b/vue-app/src/views/Join.vue
@@ -391,6 +391,7 @@
             </div>
             <div v-if="currentStep === 4">
               <h2 class="step-title">Images</h2>
+              <p>We'll upload your images to IPFS, a decentralized storage platform.</p>
               <div class="inputs">
                 <div class="form-background">
                   <form method="POST" enctype="multipart/form-data" @submit="handleUploadToIPFS" name="banner">
@@ -403,14 +404,16 @@
                       @change="handleLoadFile"
                       name="banner"
                     />
-                    <button primary="true" type='submit' label='Upload' class="btn-action upload-btn">Upload</button>
+                    <button primary="true" type='submit' label='Upload' class="btn-primary upload-btn">Upload </button>
                     <!-- p :class="{
                       error: true,
                       hidden: !$v.form.image.banner.$error
                     }">Upload a file</p -->
                   </form>
                   <div class="image-preview">
+                    <div v-if="!bannerImage" class="loader"></div>
                     <img
+                      v-else
                       :src="bannerImage"
                       alt="🌄"
                       :class="{
@@ -418,7 +421,7 @@
                         spacer: !bannerImage,
                       }"
                     />
-                    <p>Hash: {{ bannerHash }}</p>
+                    <p v-if="bannerImage">IPFS hash: {{ bannerHash }}</p>
                   </div>
                 </div>
                 <div class="form-background">
@@ -432,7 +435,7 @@
                       @change="handleLoadFile"
                       name="thumbnail"
                     />
-                    <button primary="true" type='submit' label='Upload' class="btn-action upload-btn">Upload</button>
+                    <button primary="true" type='submit' label='Upload' class="btn-primary upload-btn">Upload</button>
                     <!--p :class="{
                       error: true,
                       hidden: !$v.form.image.thumbnail.$error
@@ -1101,11 +1104,44 @@ export default class JoinView extends mixins(validationMixin) {
   }
 
   .spacer {
-    border: 2px solid $border-color;
+    border: 1px solid #000;
     border-radius: 0.5rem;
     padding: 1rem;
   }
 }
+
+.loader {
+  display: block;
+  height: 40px;
+  margin: $content-space auto;
+  width: 40px;
+}
+
+.loader:after {
+  content: " ";
+  display: block;
+  width: 32px;
+  height: 32px;
+  margin: 4px;
+  border-radius: 50%;
+  border: 6px solid #fff;
+  border-color: #fff transparent #fff transparent;
+  animation: loader 1.2s linear infinite;
+}
+
+.loader {
+    margin: $modal-space auto;
+  }
+
+@keyframes loader {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}
+
 
 .error {
   color: $error-color;

--- a/vue-app/src/views/Join.vue
+++ b/vue-app/src/views/Join.vue
@@ -393,134 +393,63 @@
               <h2 class="step-title">Images</h2>
               <div class="inputs">
                 <div class="form-background">
-                  <div class="row">
-                    <form id="uploadRadio">
-                      <div>
-                        <input
-                          id="IPFS"
-                          type="radio"
-                          name="image-requiresUpload"
-                          value="false"
-                          v-model="$v.form.image.requiresUpload.$model"
-                          :class="{
-                            input: true,
-                            invalid: $v.form.image.requiresUpload.$error
-                          }"
-                        >
-                        <label for="IPFS">IPFS – you have IPFS hashes for your images</label>
-                      </div>
-                      <div>
-                        <input
-                          id="upload"
-                          type="radio"
-                          name="image-requiresUpload"
-                          value="true"
-                          v-model="$v.form.image.requiresUpload.$model"
-                          :class="{
-                            input: true,
-                            invalid: $v.form.image.requiresUpload.$error
-                          }"
-                        >
-                        <label for="upload">Upload – you'd like to upload from your device</label>
-                      </div>
-                    </form>
-                  </div>
-                </div>
-                <div class="form-background">
                   <form method="POST" enctype="multipart/form-data" @submit="handleUploadToIPFS" name="banner">
-                    <label
-                      :for="requiresUpload ? 'image-banner-upload' : 'image-banner-hash'"
-                      class="input-label"
-                    >Banner image
-                      <p class="input-description">Recommended dimensions: 500 x 300</p>
-                    </label>
+                    <p class="input-label">Banner image</p>
+                    <p class="input-description">Recommended dimensions: 500px x 300px</p>
                     <input
-                      v-if="requiresUpload"
                       id="image-banner-upload"
                       type="file"
                       class="input"
                       @change="handleLoadFile"
                       name="banner"
                     />
-                    <p :class="{
+                    <button primary="true" type='submit' label='Upload' class="btn-action upload-btn">Upload</button>
+                    <!-- p :class="{
                       error: true,
                       hidden: !$v.form.image.banner.$error
-                    }">Upload a file</p>  
-                    <input
-                      v-if="!requiresUpload"
-                      id="image-banner-hash"
-                      placeholder="example: QmWQTJU9dMNQHJm6ZnXHi2eN5Y7hdpZaEL7o3SEGBRY8DZ"
-                      class="input"
-                      v-model="$v.form.image.banner.$model"
+                    }">Upload a file</p -->
+                  </form>
+                  <div class="preview-section">
+                    <p>Banner Image</p>
+                    <img
+                      :src="bannerImage"
+                      alt="🌄"
                       :class="{
-                        input: true,
-                        invalid: $v.form.image.banner.$error
+                        'banner-image': bannerImage,
+                        spacer: !bannerImage,
                       }"
                     />
-                    <p :class="{
-                      error: true,
-                      hidden: !$v.form.image.banner.$error
-                    }">This doesn't look like an IPFS hash</p>
-                    <button v-if="requiresUpload" primary="true" type='submit' label='Upload'>Upload</button>
-                  </form>
+                  </div>
                 </div>
                 <div class="form-background">
                   <form method="POST" enctype="multipart/form-data" @submit="handleUploadToIPFS" name="thumbnail">
-                    <label
-                      :for="requiresUpload ? 'image-thumbnail-upload' : 'image-thumbnail-hash'"
-                      class="input-label"
-                    >Thumbnail image
-                      <p class="input-description">Recommended dimensions: 80 x 80</p>
-                    </label>
+                    <p class="input-label">Thumbnail image</p>
+                    <p class="input-description">Recommended dimensions: 80px x 80px</p>
                     <input
-                      v-if="requiresUpload"
                       id="image-thumbnail-upload"
                       type="file"
                       class="input"
                       @change="handleLoadFile"
                       name="thumbnail"
                     />
-                    <p :class="{
+                    <button primary="true" type='submit' label='Upload' class="btn-action upload-btn">Upload</button>
+                    <!--p :class="{
                       error: true,
                       hidden: !$v.form.image.thumbnail.$error
-                    }">Upload a file</p>
-                    <input
-                      v-if="!requiresUpload"
-                      id="image-thumbnail-hash"
-                      placeholder="example: QmWQTJU9dMNQHJm6ZnXHi2eN5Y7hdpZaEL7o3SEGBRY8DZ"
-                      v-model="$v.form.image.thumbnail.$model"
+                    }">Upload a file</p-->
+                  </form>
+                  <div class="preview-section">
+                    <p>Thumbnail Image</p>
+                    <img
+                      :src="thumbnailImage"
+                      alt="🌄"
                       :class="{
-                        input: true,
-                        invalid: $v.form.image.thumbnail.$error
+                        'thumbnail-image': thumbnailImage,
+                        spacer: !thumbnailImage,
                       }"
                     />
-                    <p :class="{
-                      error: true,
-                      hidden: !$v.form.image.thumbnail.$error
-                    }">This doesn't look like an IPFS hash</p>
-                    <button v-if="requiresUpload" primary="true" type='submit' label='Upload'>Upload</button>
-                  </form>
+                  </div>
                 </div>
-              </div>
-              <div class="image-preview">
-                Banner Image                
-                <img
-                  :src="bannerImage"
-                  alt="Uploaded banner"
-                  :class="{
-                    'banner-image': bannerImage,
-                    hidden: !bannerImage,
-                  }"
-                />
-                Thumbnail Image                
-                <img
-                  :src="thumbnailImage"
-                  alt="Uploaded thumbnail"
-                  :class="{
-                    'thumbnail-image': thumbnailImage,
-                    hidden: !thumbnailImage,
-                  }"
-                />
               </div>
             </div>
           </form>
@@ -1145,15 +1074,37 @@ export default class JoinView extends mixins(validationMixin) {
   }
 }
 
-#uploadRadio {
+/* #uploadRadio {
   input {
     margin-right: 0.5rem;
   }
+} */
+
+.upload-btn {
+  margin-left: 1rem;
 }
 
-.banner-image {
-  width: 500px;
-  height: auto;
+.preview-section {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  align-items: flex-start;
+
+  .banner-image {
+    width: 500px;
+    height: auto;
+  }
+
+  .thumbnail-image {
+    width: 80px;
+    height: auto;
+  }
+
+  .spacer {
+    border: 2px solid $border-color;
+    border-radius: 0.5rem;
+    padding: 1rem;
+  }
 }
 
 .error {

--- a/vue-app/src/views/Join.vue
+++ b/vue-app/src/views/Join.vue
@@ -527,7 +527,6 @@ import { RecipientApplicationData } from '@/api/recipient-registry-optimistic'
         discord: { url },
       },
       image: {
-        requiresUpload: {},
         banner: {
           hash: {
             required,
@@ -580,7 +579,6 @@ export default class JoinView extends mixins(validationMixin) {
       discord: '',
     },
     image: {
-      requiresUpload: 'false',
       bannerHash: '',
       thumbnailHash: '',
       banner: {
@@ -637,10 +635,6 @@ export default class JoinView extends mixins(validationMixin) {
     if (this.currentStep < 0) {
       this.$router.push({ name: 'join' })
     }
-  }
-
-  get requiresUpload(): boolean {
-    return this.form.image.requiresUpload === 'true'
   }
 
   get bannerImage(): string {

--- a/vue-app/src/views/Join.vue
+++ b/vue-app/src/views/Join.vue
@@ -409,8 +409,7 @@
                       hidden: !$v.form.image.banner.$error
                     }">Upload a file</p -->
                   </form>
-                  <div class="preview-section">
-                    <p>Banner Image</p>
+                  <div class="image-preview">
                     <img
                       :src="bannerImage"
                       alt="🌄"
@@ -419,6 +418,7 @@
                         spacer: !bannerImage,
                       }"
                     />
+                    <p>Hash: {{ bannerHash }}</p>
                   </div>
                 </div>
                 <div class="form-background">
@@ -438,8 +438,7 @@
                       hidden: !$v.form.image.thumbnail.$error
                     }">Upload a file</p-->
                   </form>
-                  <div class="preview-section">
-                    <p>Thumbnail Image</p>
+                  <div class="image-preview">
                     <img
                       :src="thumbnailImage"
                       alt="🌄"
@@ -448,6 +447,7 @@
                         spacer: !thumbnailImage,
                       }"
                     />
+                    <p>Hash: {{ thumbnailHash }}</p>
                   </div>
                 </div>
               </div>
@@ -642,7 +642,15 @@ export default class JoinView extends mixins(validationMixin) {
   }
 
   get thumbnailImage(): string {
-    return this.form.image.banner.data
+    return this.form.image.thumbnail.data
+  }
+  
+  get bannerHash(): string {
+    return this.form.image.banner.hash
+  }
+
+  get thumbnailHash(): string {
+    return this.form.image.thumbnail.hash
   }
   
   isStepValid(step: number): boolean {
@@ -1077,11 +1085,10 @@ export default class JoinView extends mixins(validationMixin) {
   margin-left: 1rem;
 }
 
-.preview-section {
+.image-preview {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
-  align-items: flex-start;
+  margin-top: 1rem;
 
   .banner-image {
     width: 500px;


### PR DESCRIPTION
- Uses `ipfs-mini`
- `ipfs.addJSON()` used to upload and generate hash
- `ipfs.catJSON()` to fetch image from hash
- Hash and image data stored within the form state data (within `form.image.banner` and `form.image.thumbnail`)
- Forces user to upload, vs loading from an existing hash

Still needs work on styling / layout
@ryancreatescopy @samajammin 
Some questions... there are "recommended" sizes, but are we enforcing any limits to make them easier and more predictable when displaying them? And should we be limiting different file types? (ie. GIFs?)... 