### PR TITLE
Button theme cleanup

### DIFF
--- a/vue-app/src/components/NavBar.vue
+++ b/vue-app/src/components/NavBar.vue
@@ -117,6 +117,7 @@ window.onclick = function(event) {
         box-shadow: 0px 8px 16px 0px rgba(0,0,0,0.2);
         z-index: 1;
         cursor: pointer;
+        overflow: hidden;
 
         .dropdown-item a {
           display: flex;

--- a/vue-app/src/styles/_theme.scss
+++ b/vue-app/src/styles/_theme.scss
@@ -1,92 +1,58 @@
 @import "./vars";
 
-.btn-primary,
-.btn-og,
-.btn-action,
-.btn-secondary,
-.btn-alternate,
-.btn-mini,
-.btn-white,
-.btn-warning {
+@mixin button($color, $background, $border) {
   padding: 0.5rem 1.5rem;
-  border-radius: 32px;
-  color: white;
-  font-weight: 600;
+  border-radius: 2rem;
   font-size: 1rem;
+  font-weight: 600;
   line-height: 150%;
   text-align: center;
   box-sizing: border-box;
-  border: none;
+  color: $color;
+  background: $background;
+  border: $border;
   &:hover {
     opacity: 0.8;
-    transform: scale(1.01);
+    transform: scale(1.02);
     cursor: pointer;
   }
 }
 
 .btn-primary {
-  background: $clr-green;
-  border: 2px solid $clr-green;
+  @include button(white, $clr-green, 2px solid $clr-green)
 }
 
 .btn-og {
-  background: $button-color;
+  @include button(white, $button-color, none)
 }
 
 .btn-action {
-  background: $clr-pink-light-gradient;
+  @include button(white, $clr-pink-light-gradient, none)
 }
 
 .btn-secondary {
-  border: 2px solid $clr-green;
-  color: $clr-green;
-  background: none;
+  @include button($clr-green, none, 2px solid $clr-green)
 }
 
 .btn-white {
-  border: 2px solid white;
-  color: white;
-  background: #19162380;
+  @include button(white, #19162380, 2px solid white)
 }
 
 .btn-warning {
-  border: 2px solid $error-color;
-  color: $error-color;
-  background: none;
-  box-sizing: border-box;
+  @include button($error-color, none, 2px solid $error-color)
 }
 
 // app button for use in nav bar
 .app-btn {
+  @include button(white, $clr-pink-light-gradient, none);
   padding: 0.25rem 1.25rem;
-  background: $clr-pink-light-gradient;
-  border: none;
   border-radius: 1rem;
-  color: #ffffff;
-  font-size: 16px;
-  line-height: 150%;
-  &:hover {
-    opacity: 0.8;
-    transform: scale(1.01);
-    cursor: pointer;
-  }
 }
 
 .dropdown-btn {
-  background: rgba(44,41,56,1);
-  border: 1px solid rgba(115,117,166,0.3);
-  border-radius: 8px;
+  @include button(white, $bg-light-color, 1px solid rgba(115,117,166,0.3));
   padding: 0.25rem 0.5rem;
-  color: white;
+  border-radius: 8px;
   margin-right: 0.5rem;
   display: flex;
-  font-size: 16px;
-  display: flex;
-  align-items: center;
-  cursor: pointer;
-  &:hover {
-    opacity: 0.8;
-    transform: scale(1.01);
-    cursor: pointer;
-  }
 }


### PR DESCRIPTION
Created a general button mixin:
```scss
@mixin button($color, $background, $border) {
  padding: 0.5rem 1.5rem;
  border-radius: 2rem;
  font-size: 1rem;
  font-weight: 600;
  line-height: 150%;
  text-align: center;
  box-sizing: border-box;
  color: $color;
  background: $background;
  border: $border;
  &:hover {
    opacity: 0.8;
    transform: scale(1.02);
    cursor: pointer;
  }
}
```

This defines the overall layout of a button, which can be passed the three attribute that we customize most frequently, `color`, `background` and `border`. 
Makes the button styling far more readable, and removes a large amount of redundant code. 

Also
- tweaked the scale of the hover effect to make it slightly more perceptible (@ryancreatescopy feel free to revert if you don't like it)
- and made the overflow on the dropdown menu hidden (hides the hover effect at the rounded corners)