### PR TITLE
Adds tabbed summary preview

### DIFF
--- a/vue-app/src/components/Info.vue
+++ b/vue-app/src/components/Info.vue
@@ -35,6 +35,7 @@ export default class Info extends Vue {
     @media (max-width: $breakpoint-m) {
     flex-direction: column;
     padding-bottom: 1rem;
+    align-items: flex-start;
   }
 }
 

--- a/vue-app/src/components/Info.vue
+++ b/vue-app/src/components/Info.vue
@@ -1,0 +1,49 @@
+<template>
+  <div class="info">
+      <span class="icon" aria-label="info icon">ℹ</span>
+      {{message}}
+  </div>
+</template>
+
+<script lang="ts">
+import Vue from 'vue'
+import Component from 'vue-class-component'
+import { Prop } from 'vue-property-decorator'
+
+@Component
+export default class Info extends Vue { 
+  @Prop() message!: string
+}
+</script>
+
+<style scoped lang="scss">
+@import '../styles/vars';
+@import '../styles/theme';
+
+.info {
+    background: $bg-transparent;
+    border: 1px solid $highlight-color;
+    border-radius: 0.5rem;
+    padding: 0.5rem 1rem;
+    font-size: 16px;
+    font-family: Inter;
+    line-height: 150%;
+    font-weight: 500;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    @media (max-width: $breakpoint-m) {
+    flex-direction: column;
+    padding-bottom: 1rem;
+  }
+}
+
+.icon {
+    font-size: 24px;
+    padding: 0.5rem;
+    @media (max-width: $breakpoint-m) {
+    padding: 0.5rem 0rem;
+  }
+}
+
+</style>

--- a/vue-app/src/components/ProjectProfile.vue
+++ b/vue-app/src/components/ProjectProfile.vue
@@ -74,7 +74,7 @@ import Vue from 'vue'
 import Component from 'vue-class-component'
 import { Prop } from 'vue-property-decorator'
 import { Project } from '@/api/projects'
-import Info from '@/components/Info'
+import Info from '@/components/Info.vue'
 
 import Markdown from '@/components/Markdown.vue'
 

--- a/vue-app/src/components/ProjectProfile.vue
+++ b/vue-app/src/components/ProjectProfile.vue
@@ -1,6 +1,6 @@
 <template>
   <div v-if="project" class="project-page">
-    <info style="margin-bottom: 1.5rem;" message="This is what your contributors will see when they visit your project page." />
+    <info v-if="previewMode" style="margin-bottom: 1.5rem;" message="This is what your contributors will see when they visit your project page." />
     <img v-if="previewMode" class="project-image" :src="project.bannerImageUrl" :alt="project.name">
     <div class="about">    
       <h1 
@@ -87,7 +87,7 @@ import Markdown from '@/components/Markdown.vue'
 export default class ProjectProfile extends Vue {
   @Prop() project!: Project
   // @Prop() klerosCurateUrl?: string | null = null
-  @Prop() previewMode? = false
+  @Prop() previewMode!: boolean
 }
 </script>
 

--- a/vue-app/src/components/ProjectProfile.vue
+++ b/vue-app/src/components/ProjectProfile.vue
@@ -1,5 +1,6 @@
 <template>
   <div v-if="project" class="project-page">
+    <info style="margin-bottom: 1.5rem;" message="This is what your contributors will see when they visit your project page." />
     <img v-if="previewMode" class="project-image" :src="project.bannerImageUrl" :alt="project.name">
     <div class="about">    
       <h1 
@@ -73,12 +74,14 @@ import Vue from 'vue'
 import Component from 'vue-class-component'
 import { Prop } from 'vue-property-decorator'
 import { Project } from '@/api/projects'
+import Info from '@/components/Info'
 
 import Markdown from '@/components/Markdown.vue'
 
 @Component({
   components: {
     Markdown,
+    Info,
   },
 })
 export default class ProjectProfile extends Vue {
@@ -217,6 +220,7 @@ export default class ProjectProfile extends Vue {
       }
     }
   }
+
 
   .sticky-column {
     position: sticky;

--- a/vue-app/src/views/Join.vue
+++ b/vue-app/src/views/Join.vue
@@ -1262,7 +1262,8 @@ export default class JoinView extends mixins(validationMixin) {
     cursor: pointer;
     &:hover {
       opacity: 0.8;
-      transform: scale(1.02);  
+      border-bottom: 4px solid #fff7;  
+      border-radius: 4px;
     }
     /* text-decoration: underline; */
   }

--- a/vue-app/src/views/Join.vue
+++ b/vue-app/src/views/Join.vue
@@ -59,16 +59,13 @@
         </div>
       </div>
       <div class="title-area">
-        <div class="desktop">
-          <h1 class="desktop">Join the round</h1>
-          <div v-if="currentStep === 5">
-            <div class="toggle-tabs-desktop">
-              <p class="tab" id="review" :class="showSummaryPreview ? 'inactive-tab' : 'active-tab'" @click="handleToggleTab">Review info</p>
-              <p class="tab" id="preview" :class="showSummaryPreview ? 'active-tab' : 'inactive-tab'" @click="handleToggleTab">Preview project</p>
-            </div>
+        <h1>Join the round</h1>
+        <div v-if="currentStep === 5">
+          <div class="toggle-tabs-desktop">
+            <p class="tab" id="review" :class="showSummaryPreview ? 'inactive-tab' : 'active-tab'" @click="handleToggleTab">Review info</p>
+            <p class="tab" id="preview" :class="showSummaryPreview ? 'active-tab' : 'inactive-tab'" @click="handleToggleTab">Preview project</p>
           </div>
         </div>
-        <h1 class="mobile">Join the round</h1>
       </div>
       <div class="cancel-area desktop">
         <router-link class="cancel-link" to="/join">
@@ -76,12 +73,6 @@
         </router-link>
       </div>
       <div class="form-area">
-        <div class="mobile" v-if="currentStep === 5">
-          <div class="toggle-tabs-mobile">
-            <p class="tab" id="review" :class="showSummaryPreview ? 'inactive-tab' : 'active-tab'" @click="handleToggleTab">Review info</p>
-            <p class="tab" id="preview" :class="showSummaryPreview ? 'active-tab' : 'inactive-tab'" @click="handleToggleTab">Preview project</p>
-          </div>
-        </div>
         <div class="application">
           <form>
             <div v-if="currentStep === 0">
@@ -932,25 +923,21 @@ export default class JoinView extends mixins(validationMixin) {
   grid-area: title;
   display: flex;
   padding: 1rem;
+  padding-left: 0rem; 
   justify-content: space-between;
-  .desktop {
-    padding-left: 0rem; 
-    font-family: 'Glacial Indifference', sans-serif;
-    font-weight: 00;
-    align-items: flex-start;
+  align-items: flex-start;
+  flex-direction: column;
+
+  h1 {
+    font-family: "Glacial Indifference", sans-serif;
   }
-  .mobile {
+
+  @media (max-width: $breakpoint-m) {
     margin-top: 2rem;
     padding-bottom: 0;
-    display: flex;
-    font-family: 'Glacial Indifference', sans-serif;
+    padding-left: 1rem; 
     font-size: 14px;
     font-weight: normal;
-    letter-spacing: 6px;
-    margin-top: 2rem;;
-    text-transform: uppercase;
-    justify-content: flex-start;
-    align-items: center;  
   }
 }
 
@@ -1248,7 +1235,7 @@ export default class JoinView extends mixins(validationMixin) {
     /* flex-direction: column;
     gap: 0;
     margin-left: 0rem; */
-    display: none;
+    /* display: none; */
   }
   .active-tab{
     padding-bottom: 0.5rem;

--- a/vue-app/src/views/Join.vue
+++ b/vue-app/src/views/Join.vue
@@ -68,9 +68,11 @@
         </router-link>
       </div>
       <div class="form-area">
-        <div v-if="currentStep === 5" class="application">
-          <div class="btn-primary" style="width: fit-content;" @click="togglePreview">{{ showSummaryPreview ? 'Close' : 'Preview' }}</div>
-          <project-profile v-if="showSummaryPreview" :project="projectInterface" :previewMode="true" class="project-details" />
+        <div v-if="currentStep === 5">
+          <div class="toggle-tabs">
+            <p class="tab" id="review" :class="{'naked-link': showSummaryPreview}" @click="handleToggleTab">Review items</p>
+            <p class="tab" id="preview" :class="{'naked-link': !showSummaryPreview}" @click="handleToggleTab">Preview listing</p>
+          </div>
         </div>
         <div class="application">
           <form>
@@ -433,113 +435,117 @@
             </div>
           </form>
           <div v-if="currentStep === 5" id="summary">
-            <h2 class="step-title">Review your information</h2>
-            <warning style="margin-bottom: 1rem;" message="This information will be stored in a smart contract, so please review carefully. There’s a transaction fee for every edit once you’ve sent your application." /> 
-            <div class="form-background">
-              <div class="summary-section-header">
-                <h3 class="step-subtitle">About the project</h3>
-                <router-link to="/join/project" class="edit-button">Edit <img width="16px" src="@/assets/edit.svg" /></router-link>
+            <project-profile v-if="showSummaryPreview" :project="projectInterface" :previewMode="true" class="project-details" />
+            <div v-if="!showSummaryPreview">
+              <h2 class="step-title">Review your information</h2>
+              <warning style="margin-bottom: 1rem;" message="This information will be stored in a smart contract, so please review carefully. There’s a transaction fee for every edit once you’ve sent your application." /> 
+              <div class="form-background">
+                <div class="summary-section-header">
+                  <h3 class="step-subtitle">About the project</h3>
+                  <router-link to="/join/project" class="edit-button">Edit <img width="16px" src="@/assets/edit.svg" /></router-link>
+                </div>
+                <div class="summary">
+                  <h4 class="read-only-title">Name</h4>
+                  <div class="data">{{form.project.name}}</div>
+                </div>
+                <div class="summary">
+                  <h4 class="read-only-title">Tagline</h4>
+                  <div class="data">{{form.project.tagline}} </div>
+                </div>
+                <div class="summary">
+                  <h4 class="read-only-title">Description</h4>
+                  <div class="data">{{form.project.description}} </div>
+                </div>
+                <div class="summary">
+                  <h4 class="read-only-title">Category</h4>
+                  <div class="data">{{form.project.category}} </div>
+                </div>
+                <div class="summary">
+                  <h4 class="read-only-title">Problem space</h4>
+                  <div class="data">{{form.project.problemSpace}} </div>
+                </div>
               </div>
-              <div class="summary">
-                <h4 class="read-only-title">Name</h4>
-                <div class="data">{{form.project.name}}</div>
+              <div class="form-background">
+                <div class="summary-section-header">
+                  <h3 class="step-subtitle">Funding details</h3>
+                  <router-link to="/join/fund" class="edit-button">Edit <img width="16px" src="@/assets/edit.svg" /></router-link>
+                </div>
+                <div class="summary">
+                  <h4 class="read-only-title">Ethereum address</h4>
+                  <div class="data">{{form.fund.address}} <a :href="'https://etherscan.io/address/' + form.fund.address" target="_blank">View on Etherscan</a></div>
+                </div>
+                <div class="summary">
+                  <h4 class="read-only-title">Funding plans</h4>
+                  <div class="data">{{form.fund.plans}} </div>
+                </div>
               </div>
-              <div class="summary">
-                <h4 class="read-only-title">Tagline</h4>
-                <div class="data">{{form.project.tagline}} </div>
-              </div>
-              <div class="summary">
-                <h4 class="read-only-title">Description</h4>
-                <div class="data">{{form.project.description}} </div>
-              </div>
-              <div class="summary">
-                <h4 class="read-only-title">Category</h4>
-                <div class="data">{{form.project.category}} </div>
-              </div>
-              <div class="summary">
-                <h4 class="read-only-title">Problem space</h4>
-                <div class="data">{{form.project.problemSpace}} </div>
+              <div class="form-background">
+                <div class="summary-section-header">
+                  <h3 class="step-subtitle">Team details</h3>
+                  <router-link to="/join/team" class="edit-button">Edit <img width="16px" src="@/assets/edit.svg" /></router-link>
+                </div>
+                <div class="summary">
+                  <h4 class="read-only-title">Contact email</h4>
+                  <div class="data">{{form.team.email}} </div>
+                  <div class="input-notice">This information won't be added to the smart contract. It won't cost anything to edit and will only be used to contact you about the round and/or your project.</div>
+                </div>
+                <div class="summary">
+                  <h4 class="read-only-title">Team name</h4>
+                  <div class="data">{{form.team.name}} </div>
+                  <div class="data" v-if="!form.team.name">Not provided</div>
+                </div>
+                <div class="summary">
+                  <h4 class="read-only-title">Team description</h4>
+                  <div class="data">{{form.team.description}} </div>
+                  <div class="data" v-if="!form.team.description">Not provided</div>
+                </div>
+              </div>  
+              <div class="form-background">
+                <div class="summary-section-header">
+                  <h3 class="step-subtitle">Links</h3>
+                  <router-link to="/join/links" class="edit-button">Edit <img width="16px" src="@/assets/edit.svg" /></router-link>
+                </div>
+                <div class="summary">
+                  <h4 class="read-only-title">GitHub</h4>
+                  <div class="data">{{form.links.github}} <a v-if="form.links.github" :href=form.links.github><img width="16px" src="@/assets/link.svg" /></a></div>
+                  <div class="data" v-if="!form.links.github">Not provided</div>
+                </div>
+                <div class="summary">
+                  <h4 class="read-only-title">Twitter</h4>
+                  <div class="data">{{form.links.twitter}} <a v-if="form.links.twitter" :href=form.links.twitter><img width="16px" src="@/assets/link.svg" /></a></div>
+                  <div class="data" v-if="!form.links.twitter">Not provided</div>
+                </div>
+                <div class="summary">
+                  <h4 class="read-only-title">Website</h4>
+                  <div class="data" key="">{{form.links.website}} <a v-if="form.links.website" :href=form.links.website><img width="16px" src="@/assets/link.svg" /></a></div>
+                  <div class="data" v-if="!form.links.website">Not provided</div>
+                </div>
+                <div class="summary">
+                  <h4 class="read-only-title">Discord</h4>
+                  <div class="data">{{form.links.discord}} <a v-if="form.links.discord" :href=form.links.discord><img width="16px" src="@/assets/link.svg" /></a></div>
+                  <div class="data" v-if="!form.links.discord">Not provided</div>
+                </div>
+                <div class="summary">
+                  <h4 class="read-only-title">Radicle</h4>
+                  <div class="data">{{form.links.radicle}} <a v-if="form.links.radicle" :href=form.links.radicle><img width="16px" src="@/assets/link.svg" /></a></div>
+                  <div class="data" v-if="!form.links.radicle">Not provided</div>
+                </div>
+              </div>  
+              <div class="form-background">
+                <div class="summary-section-header">
+                  <h3 class="step-subtitle">Images</h3>
+                  <router-link to="/join/image" class="edit-button">Edit <img width="16px" src="@/assets/edit.svg" /></router-link>
+                </div>
+                <div class="summary">
+                  <h4 class="read-only-title">Banner</h4>
+                  <div class="data">{{form.image.bannerHash}} </div>
+                </div>
+                <div class="summary">
+                  <h4 class="read-only-title">Thumbnail</h4>
+                  <div class="data">{{form.image.thumbnailHash}} </div>
+                </div>
               </div>
             </div>
-            <div class="form-background">
-              <div class="summary-section-header">
-                <h3 class="step-subtitle">Funding details</h3>
-                <router-link to="/join/fund" class="edit-button">Edit <img width="16px" src="@/assets/edit.svg" /></router-link>
-              </div>
-              <div class="summary">
-                <h4 class="read-only-title">Ethereum address</h4>
-                <div class="data">{{form.fund.address}} <a :href="'https://etherscan.io/address/' + form.fund.address" target="_blank">View on Etherscan</a></div>
-              </div>
-              <div class="summary">
-                <h4 class="read-only-title">Funding plans</h4>
-                <div class="data">{{form.fund.plans}} </div>
-              </div>
-            </div>
-            <div class="form-background">
-              <div class="summary-section-header">
-                <h3 class="step-subtitle">Team details</h3>
-                <router-link to="/join/team" class="edit-button">Edit <img width="16px" src="@/assets/edit.svg" /></router-link>
-              </div>
-              <div class="summary">
-                <h4 class="read-only-title">Contact email</h4>
-                <div class="data">{{form.team.email}} </div>
-                <div class="input-notice">This information won't be added to the smart contract. It won't cost anything to edit and will only be used to contact you about the round and/or your project.</div>
-              </div>
-              <div class="summary">
-                <h4 class="read-only-title">Team name</h4>
-                <div class="data">{{form.team.name}} </div>
-                <div class="data" v-if="!form.team.name">Not provided</div>
-              </div>
-              <div class="summary">
-                <h4 class="read-only-title">Team description</h4>
-                <div class="data">{{form.team.description}} </div>
-                <div class="data" v-if="!form.team.description">Not provided</div>
-              </div>
-            </div>  
-            <div class="form-background">
-              <div class="summary-section-header">
-                <h3 class="step-subtitle">Links</h3>
-                <router-link to="/join/links" class="edit-button">Edit <img width="16px" src="@/assets/edit.svg" /></router-link>
-              </div>
-              <div class="summary">
-                <h4 class="read-only-title">GitHub</h4>
-                <div class="data">{{form.links.github}} <a v-if="form.links.github" :href=form.links.github><img width="16px" src="@/assets/link.svg" /></a></div>
-                <div class="data" v-if="!form.links.github">Not provided</div>
-              </div>
-              <div class="summary">
-                <h4 class="read-only-title">Twitter</h4>
-                <div class="data">{{form.links.twitter}} <a v-if="form.links.twitter" :href=form.links.twitter><img width="16px" src="@/assets/link.svg" /></a></div>
-                <div class="data" v-if="!form.links.twitter">Not provided</div>
-              </div>
-              <div class="summary">
-                <h4 class="read-only-title">Website</h4>
-                <div class="data" key="">{{form.links.website}} <a v-if="form.links.website" :href=form.links.website><img width="16px" src="@/assets/link.svg" /></a></div>
-                <div class="data" v-if="!form.links.website">Not provided</div>
-              </div>
-              <div class="summary">
-                <h4 class="read-only-title">Discord</h4>
-                <div class="data">{{form.links.discord}} <a v-if="form.links.discord" :href=form.links.discord><img width="16px" src="@/assets/link.svg" /></a></div>
-                <div class="data" v-if="!form.links.discord">Not provided</div>
-              </div>
-              <div class="summary">
-                <h4 class="read-only-title">Radicle</h4>
-                <div class="data">{{form.links.radicle}} <a v-if="form.links.radicle" :href=form.links.radicle><img width="16px" src="@/assets/link.svg" /></a></div>
-                <div class="data" v-if="!form.links.radicle">Not provided</div>
-              </div>
-            </div>  
-            <div class="form-background">
-              <div class="summary-section-header">
-                <h3 class="step-subtitle">Images</h3>
-                <router-link to="/join/image" class="edit-button">Edit <img width="16px" src="@/assets/edit.svg" /></router-link>
-              </div>
-               <div class="summary">
-                <h4 class="read-only-title">Banner</h4>
-                <div class="data">{{form.image.bannerHash}} </div>
-              </div>
-              <div class="summary">
-                <h4 class="read-only-title">Thumbnail</h4>
-                <div class="data">{{form.image.thumbnailHash}} </div>
-              </div>            </div>  
             <!-- {{form}}-->
             <!--TODO: this will be an on-chain transaction so double check all info and links are correct as it will cost you you to change it -->
           </div>
@@ -695,59 +701,50 @@ export default class JoinView extends mixins(validationMixin) {
       this.$router.push({ name: 'joinStep', params: { step: steps[this.form.furthestStep] }})
     }
 
-    //     if (process.env.NODE_ENV === 'development') {
-    //       this.form = {
-    //         project: {
-    //           name: 'CLR.Fund',
-    //           tagline: 'A quadratic funding protocol',
-    //           description: `**CLR.fund** is a quadratic funding protocol that aims to make it as easy as possible to set up, manage, and participate in quadratic funding rounds...
-    // # Derp
+    // if (process.env.NODE_ENV === 'development') {
+    //   this.form = {
+    //     project: {
+    //       name: 'CLR.Fund',
+    //       tagline: 'A quadratic funding protocol',
+    //       description: '**CLR.fund** is a quadratic funding protocol that aims to make it as easy as possible to set up, manage, and participate in quadratic funding rounds...\n# Derp\n\nasdfasdfasdf\n\n## Derp\n\nasdfsdasdfsdf\n### Derp\n\nasdfasdfsdaf\n#### Derp\nasdfasdf\n##### Derp',
+    //       category: 'research',
+    //       problemSpace: 'There is no way to spin up a quadratic funding round. Right now, you have to collaborate with GitCoin Grants which isn’t a scalable or sustainable model.',
+    //     },
+    //     fund: {
+    //       address: '0x4351f1F0eEe77F0102fF70D5197cCa7aa6c91EA2',
+    //       plans: 'Create much wow, when lambo?',
+    //     },
+    //     team: {
+    //       name: 'clr.fund',
+    //       description: 'clr.fund team **rules**',
+    //       email: 'doge@goodboi.com',
+    //     },
+    //     links: {
+    //       github: '',
+    //       radicle: '',
+    //       website: 'https://clr.fund',
+    //       twitter: '',
+    //       discord: '',
+    //       hasLink: true,
+    //     },
+    //     image: {
+    //       bannerHash: 'QmbMP2fMiy6ek5uQZaxG3bzT9gSqMWxpdCUcQg1iSeEFMU',
+    //       thumbnailHash: 'QmbMP2fMiy6ek5uQZaxG3bzT9gSqMWxpdCUcQg1iSeEFMU',
+    //     },
+    //     furthestStep: 5,
+    //   }
+    //   this.saveFormData()
+    // }
+  }
 
-    // asdfasdfasdf
-
-    // ## Derp
-
-    // asdfsdasdfsdf
-    // ### Derp
-
-    // asdfasdfsdaf
-    // #### Derp
-    // asdfasdf
-    // ##### Derp
-
-    //           `,
-    //           category: 'research',
-    //           problemSpace: 'There is no way to spin up a quadratic funding round. Right now, you have to collaborate with GitCoin Grants which isn’t a scalable or sustainable model.',
-    //         },
-    //         fund: {
-    //           address: '0x4351f1F0eEe77F0102fF70D5197cCa7aa6c91EA2',
-    //           plans: 'Create much wow, when lambo?',
-    //         },
-    //         team: {
-    //           name: 'clr.fund',
-    //           description: `CLR.fund is a quadratic funding protocol that aims to make it as easy as possible to set up, manage, and participate in quadratic funding rounds...
-    // # Forr
-    // ## Bar
-    // ## Derp
-    // `,
-    //           email: 'doge@goodboi.com',
-    //         },
-    //         links: {
-    //           github: '',
-    //           radicle: '',
-    //           website: 'https://clr.fund',
-    //           twitter: '',
-    //           discord: '',
-    //           hasLink: true,
-    //         },
-    //         image: {
-    //           bannerHash: 'QmbMP2fMiy6ek5uQZaxG3bzT9gSqMWxpdCUcQg1iSeEFMU',
-    //           thumbnailHash: 'QmbMP2fMiy6ek5uQZaxG3bzT9gSqMWxpdCUcQg1iSeEFMU',
-    //         },
-    //         furthestStep: 5,
-    //       }
-    //       this.saveFormData()
-    //     }
+  handleToggleTab(event): void {
+    const { id } = event.target
+    // Guard clause: 
+    if (
+      (!this.showSummaryPreview && id === 'review') ||
+      (this.showSummaryPreview && id === 'preview')
+    ) return
+    this.showSummaryPreview = !this.showSummaryPreview
   }
 
   handleLinkUpdate(): void {
@@ -775,7 +772,7 @@ export default class JoinView extends mixins(validationMixin) {
     if (updateFurthest && this.currentStep + 1 > this.form.furthestStep) {
       this.form.furthestStep = this.currentStep + 1
     }
-    if (typeof this.currentStep !== 'number') { return }
+    if (typeof this.currentStep !== 'number') return
     this.$store.commit(SET_RECIPIENT_DATA, {
       updatedData: this.form,
       step: this.steps[this.currentStep],
@@ -815,10 +812,6 @@ export default class JoinView extends mixins(validationMixin) {
 
   get furthestStep() {
     return this.form.furthestStep
-  }
-
-  togglePreview(): void {
-    this.showSummaryPreview = !this.showSummaryPreview
   }
 } 
 </script>
@@ -1233,6 +1226,21 @@ export default class JoinView extends mixins(validationMixin) {
   margin-bottom: 1.5rem;
   border-bottom: 1px solid $highlight-color;
   padding-bottom: 0.5rem;
+}
+
+.toggle-tabs {
+  display: flex;
+  gap: 2rem;
+  @media (max-width: $breakpoint-m) {
+    flex-direction: column;
+    gap: 0;
+  }
+  .naked-link {
+    text-decoration: underline;
+    &:hover {
+      cursor: pointer;
+    }
+  }
 }
 
 .step-subtitle {

--- a/vue-app/src/views/Join.vue
+++ b/vue-app/src/views/Join.vue
@@ -933,11 +933,11 @@ export default class JoinView extends mixins(validationMixin) {
   display: flex;
   padding: 1rem;
   justify-content: space-between;
-  align-items: center;
   .desktop {
     padding-left: 0rem; 
     font-family: 'Glacial Indifference', sans-serif;
     font-weight: 00;
+    align-items: flex-start;
   }
   .mobile {
     margin-top: 2rem;
@@ -950,6 +950,7 @@ export default class JoinView extends mixins(validationMixin) {
     margin-top: 2rem;;
     text-transform: uppercase;
     justify-content: flex-start;
+    align-items: center;  
   }
 }
 
@@ -1218,7 +1219,6 @@ export default class JoinView extends mixins(validationMixin) {
 }
 
 .project-details {
-  margin-top: 2rem;
   &:last-child {
     margin-bottom: 0;
   }

--- a/vue-app/src/views/Join.vue
+++ b/vue-app/src/views/Join.vue
@@ -70,8 +70,8 @@
       <div class="form-area">
         <div v-if="currentStep === 5">
           <div class="toggle-tabs">
-            <p class="tab" id="review" :class="{'naked-link': showSummaryPreview}" @click="handleToggleTab">Review items</p>
-            <p class="tab" id="preview" :class="{'naked-link': !showSummaryPreview}" @click="handleToggleTab">Preview listing</p>
+            <p class="tab" id="review" :class="showSummaryPreview ? 'inactive-tab' : 'active-tab'" @click="handleToggleTab">Review info</p>
+            <p class="tab" id="preview" :class="showSummaryPreview ? 'active-tab' : 'inactive-tab'" @click="handleToggleTab">Preview project</p>
           </div>
         </div>
         <div class="application">
@@ -1231,15 +1231,27 @@ export default class JoinView extends mixins(validationMixin) {
 .toggle-tabs {
   display: flex;
   gap: 2rem;
+  margin-left: 1rem;
   @media (max-width: $breakpoint-m) {
-    flex-direction: column;
-    gap: 0;
+    /* flex-direction: column;
+    gap: 0; */
+    margin-left: 0rem;
   }
-  .naked-link {
-    text-decoration: underline;
+  .active-tab{
+    padding-bottom: 0.5rem;
+    border-bottom: 4px solid $clr-green;
+    border-radius: 4px;
+    font-weight: 600;
+    /* text-decoration: underline; */
+  }
+  .inactive-tab{
+    padding-bottom: 0.5rem;
+    cursor: pointer;
     &:hover {
-      cursor: pointer;
+      opacity: 0.8;
+      transform: scale(1.02);  
     }
+    /* text-decoration: underline; */
   }
 }
 

--- a/vue-app/src/views/Join.vue
+++ b/vue-app/src/views/Join.vue
@@ -1010,6 +1010,9 @@ export default class JoinView extends mixins(validationMixin) {
   font-size: 1.5rem;
   margin-top: 1rem;
   font-weight: 600;
+  &:first-of-type {
+    margin-top: 0;
+  }
 }
 
 .row {

--- a/vue-app/src/views/Join.vue
+++ b/vue-app/src/views/Join.vue
@@ -59,7 +59,15 @@
         </div>
       </div>
       <div class="title-area">
-        <h1 class="desktop">Join the round</h1>
+        <div class="desktop">
+          <h1 class="desktop">Join the round</h1>
+          <div v-if="currentStep === 5">
+            <div class="toggle-tabs-desktop">
+              <p class="tab" id="review" :class="showSummaryPreview ? 'inactive-tab' : 'active-tab'" @click="handleToggleTab">Review info</p>
+              <p class="tab" id="preview" :class="showSummaryPreview ? 'active-tab' : 'inactive-tab'" @click="handleToggleTab">Preview project</p>
+            </div>
+          </div>
+        </div>
         <h1 class="mobile">Join the round</h1>
       </div>
       <div class="cancel-area desktop">
@@ -68,8 +76,8 @@
         </router-link>
       </div>
       <div class="form-area">
-        <div v-if="currentStep === 5">
-          <div class="toggle-tabs">
+        <div class="mobile" v-if="currentStep === 5">
+          <div class="toggle-tabs-mobile">
             <p class="tab" id="review" :class="showSummaryPreview ? 'inactive-tab' : 'active-tab'" @click="handleToggleTab">Review info</p>
             <p class="tab" id="preview" :class="showSummaryPreview ? 'active-tab' : 'inactive-tab'" @click="handleToggleTab">Preview project</p>
           </div>
@@ -934,13 +942,14 @@ export default class JoinView extends mixins(validationMixin) {
   .mobile {
     margin-top: 2rem;
     padding-bottom: 0;
-    display: block;
+    display: flex;
     font-family: 'Glacial Indifference', sans-serif;
     font-size: 14px;
     font-weight: normal;
     letter-spacing: 6px;
     margin-top: 2rem;;
     text-transform: uppercase;
+    justify-content: flex-start;
   }
 }
 
@@ -1228,14 +1237,15 @@ export default class JoinView extends mixins(validationMixin) {
   padding-bottom: 0.5rem;
 }
 
-.toggle-tabs {
+.toggle-tabs-desktop {
   display: flex;
   gap: 2rem;
-  margin-left: 1rem;
+  font-family: "Inter";     
   @media (max-width: $breakpoint-m) {
     /* flex-direction: column;
-    gap: 0; */
-    margin-left: 0rem;
+    gap: 0;
+    margin-left: 0rem; */
+    display: none;
   }
   .active-tab{
     padding-bottom: 0.5rem;
@@ -1254,6 +1264,33 @@ export default class JoinView extends mixins(validationMixin) {
     /* text-decoration: underline; */
   }
 }
+
+.toggle-tabs-mobile {
+    display: flex;
+    gap: 2rem;
+  @media (min-width: $breakpoint-m) {
+    /* flex-direction: column;
+    gap: 0;
+    margin-left: 0rem; */
+    display: none;
+  }
+   .active-tab{
+    padding-bottom: 0.5rem;
+    border-bottom: 4px solid $clr-green;
+    border-radius: 4px;
+    font-weight: 600;
+    /* text-decoration: underline; */
+  }
+  .inactive-tab{
+    padding-bottom: 0.5rem;
+    cursor: pointer;
+    &:hover {
+      opacity: 0.8;
+      transform: scale(1.02);  
+    }
+    /* text-decoration: underline; */
+  }
+} 
 
 .step-subtitle {
   margin: 0.5rem 0;


### PR DESCRIPTION
Adds `Review items` and `Preview listing` "tabs" at the top of the summary page

Some side notes:
- Regarding form submission flow: While preview is shown, this blocks the "Review" view which has edit buttons. This could be utilized while submitting the form: Toggle summary to "preview" mode on submit
- IPFS Hash being used for testing is `QmbMP2fMiy6ek5uQZaxG3bzT9gSqMWxpdCUcQg1iSeEFMU` (the banner being used for the other dummy projects... It's not showing up on this preview, which I find odd given this is a hash that is loading elsewhere on the site using `https://ipfs.io/ipfs/{hash}`.
- IPFS hash on "review" page overflows div on mobile