### PR TITLE
User/app status bar

### DIFF
--- a/vue-app/src/App.vue
+++ b/vue-app/src/App.vue
@@ -15,6 +15,7 @@
           <a href="https://github.com/clrfund/monorepo/" target="_blank" rel="noopener">GitHub</a> -->
       </div>
       <div id="content" :class="{ padded: !isSidebarCollapsed }">
+        <user-status />
         <router-view :key="$route.path" />
       </div>
     </div>
@@ -25,7 +26,7 @@
 import Vue from 'vue'
 import Component from 'vue-class-component'
 import { Watch } from 'vue-property-decorator'
-
+import UserStatus from '@/components/UserStatus.vue'
 import { recipientRegistryType } from '@/api/core'
 // import Cart from '@/components/Cart.vue'
 // import WalletWidget from '@/components/WalletWidget.vue'
@@ -47,7 +48,7 @@ import { LOAD_USER_INFO, LOAD_ROUND_INFO } from '@/store/action-types'
       },
     ],
   },
-  components: { RoundInformation, NavBar, Cart },
+  components: { RoundInformation, NavBar, Cart, UserStatus },
 })
 export default class App extends Vue {
   created() {

--- a/vue-app/src/components/UserStatus.vue
+++ b/vue-app/src/components/UserStatus.vue
@@ -1,0 +1,55 @@
+<template>
+  <div class="info">
+      <div v-if="cantContribute">The round is now closed for contributions.</div>
+      <div v-if="reallocationPhase">If you contributed, you have X days to change your cart before we close the round.</div>
+      <div v-if="finalisedPhase">Calling all project owners: your funds are ready to claim. Head to your project page.</div>
+  </div>
+</template>
+
+<script lang="ts">
+import Vue from 'vue'
+import Component from 'vue-class-component'
+import { Prop } from 'vue-property-decorator'
+
+@Component
+export default class UserStatus extends Vue { 
+    cantContribute = true
+    reallocationPhase = true
+    finalisedPhase = true
+  @Prop() message!: string
+}
+</script>
+
+<style scoped lang="scss">
+@import '../styles/vars';
+@import '../styles/theme';
+
+.info {
+    background: $bg-transparent;
+    border: 1px solid $highlight-color;
+    border-radius: 0.5rem;
+    padding: 0.5rem 1rem;
+    font-size: 16px;
+    font-family: Inter;
+    line-height: 150%;
+    font-weight: 500;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin-top: 0.5rem;
+    @media (max-width: $breakpoint-m) {
+    flex-direction: column;
+    padding-bottom: 1rem;
+    align-items: flex-start;
+  }
+}
+
+.icon {
+    font-size: 24px;
+    padding: 0.5rem;
+    @media (max-width: $breakpoint-m) {
+    padding: 0.5rem 0rem;
+  }
+}
+
+</style>


### PR DESCRIPTION
This is just the scaffolding right now, but I wonder whether we need a banner that explains to users why they may not be able to do certain actions or to draw attention to certain things. Currently have conditionals for:

- only reallocation is possible
- not user action is possible, e.g. post-reallocation phase
- project owners can now claim (maybe we make this smarter and have the claim button in the banner if the user is connected?)

Would be keen for peoples thoughts on this? Do we think this is needed with the round status stuff in the round information ccolumn?