### PR TITLE
Layout issues for roundinfo

### DIFF
--- a/vue-app/src/components/ProjectProfile.vue
+++ b/vue-app/src/components/ProjectProfile.vue
@@ -173,6 +173,7 @@ export default class ProjectProfile extends Vue {
     } catch (error) {
       console.warn('Error in copying text: ', error) /* eslint-disable-line no-console */
     }
+  }
 
   private async checkAllocation(tally: Tally | null) {
     const currentRound = this.$store.state.currentRound

--- a/vue-app/src/components/RoundInformation.vue
+++ b/vue-app/src/components/RoundInformation.vue
@@ -150,7 +150,7 @@
             </div>
             <div class="round-info-value">
               <div class="value">{{ formatIntegerPart(currentRound.contributions) }}</div>
-              <div class="value extra">{{ formatFractionalPart(currentRound.contributions) }}</div>
+              <div class="value">{{ formatFractionalPart(currentRound.contributions) }}</div>
               <div class="unit">{{ currentRound.nativeTokenSymbol }}</div>
             </div>
           </div>

--- a/vue-app/src/components/RoundInformation.vue
+++ b/vue-app/src/components/RoundInformation.vue
@@ -109,8 +109,7 @@
               <tooltip position="right" content="This total includes the funds in the matching pool and all contributions from the community."><img style="opacity: 0.6;" width="16px" src="@/assets/info.svg" /></tooltip>
             </div>
             <div class="round-info-value">
-              <div class="value large">{{ formatIntegerPart(currentRound.contributions) + formatIntegerPart(currentRound.matchingPool) }}</div>
-              <div class="value extra">{{ formatFractionalPart(currentRound.contributions) + formatFractionalPart(currentRound.matchingPool) }}</div>
+              <div class="value large">{{ formatAmount(currentRound.contributions) + formatAmount(currentRound.matchingPool) }}</div>
               <div class="unit">{{ currentRound.nativeTokenSymbol }}</div>
             </div>
           </div>
@@ -182,14 +181,14 @@
 <script lang="ts">
 import Vue from 'vue'
 import Component from 'vue-class-component'
-import { FixedNumber } from 'ethers'
+import { BigNumber, FixedNumber } from 'ethers'
 import { DateTime } from 'luxon'
 
 import { RoundInfo, getCurrentRound, TimeLeft } from '@/api/round'
 import { Project, getRecipientRegistryAddress, getProjects } from '@/api/projects'
 
 import { getTimeLeft } from '@/utils/dates'
-
+import { formatAmount } from '@/utils/amounts'
 import ProjectListItem from '@/components/ProjectListItem.vue'
 import Tooltip from '@/components/Tooltip.vue'
 import MatchingFundsModal from '@/components/MatchingFundsModal.vue'
@@ -289,6 +288,11 @@ export default class RoundInformation extends Vue {
 
   formatDate(value: DateTime): string {
     return value.toLocaleString(DateTime.DATETIME_SHORT) || ''
+  }
+
+  formatAmount(value: BigNumber): string {
+    const decimals = this.$store.state.currentRound.nativeTokenDecimals
+    return formatAmount(value, decimals)
   }
 
   get contributionTimeLeft(): TimeLeft {

--- a/vue-app/src/components/RoundInformation.vue
+++ b/vue-app/src/components/RoundInformation.vue
@@ -168,7 +168,7 @@
               </div>
               <div class="round-info-value">
                 <div class="value">{{ currentRound.contributors }}</div>
-                <div class="unit">legends</div>
+                <div class="unit">legend{{ currentRound.contributors !== 1 ? "s": "" }}</div>
               </div>
             </div>
         </div>

--- a/vue-app/src/components/RoundInformation.vue
+++ b/vue-app/src/components/RoundInformation.vue
@@ -109,7 +109,7 @@
               <tooltip position="right" content="This total includes the funds in the matching pool and all contributions from the community."><img style="opacity: 0.6;" width="16px" src="@/assets/info.svg" /></tooltip>
             </div>
             <div class="round-info-value">
-              <div class="value large">{{ formatAmount(currentRound.contributions) + formatAmount(currentRound.matchingPool) }}</div>
+              <div class="value large">{{ formatTotalInRound }}</div>
               <div class="unit">{{ currentRound.nativeTokenSymbol }}</div>
             </div>
           </div>
@@ -274,6 +274,30 @@ export default class RoundInformation extends Vue {
     return this.$store.state.currentRound
   }
 
+  get contributionTimeLeft(): TimeLeft {
+    return getTimeLeft(this.$store.state.currentRound.signUpDeadline)
+  }
+
+  get reallocationTimeLeft(): TimeLeft {
+    return getTimeLeft(this.$store.state.currentRound.votingDeadline)
+  }
+
+  get formatTotalInRound(): string {
+    const { currentRound } = this.$store.state
+    const totalInRound = currentRound.contributions.addUnsafe(currentRound.matchingPool)
+    
+    return this.formatAmount(totalInRound)
+  }
+
+  get filteredProjects(): Project[] {
+    return this.projects.filter((project: Project) => {
+      if (!this.search) {
+        return true
+      }
+      return project.name.toLowerCase().includes(this.search.toLowerCase())
+    })
+  }
+
   formatIntegerPart(value: FixedNumber): string {
     if (value._value === '0.0') {
       return '0'
@@ -295,14 +319,6 @@ export default class RoundInformation extends Vue {
     return formatAmount(value, decimals)
   }
 
-  get contributionTimeLeft(): TimeLeft {
-    return getTimeLeft(this.$store.state.currentRound.signUpDeadline)
-  }
-
-  get reallocationTimeLeft(): TimeLeft {
-    return getTimeLeft(this.$store.state.currentRound.votingDeadline)
-  }
-
   addMatchingFunds(): void {
     if (!this.$store.state.currentUser) {
       return
@@ -318,15 +334,6 @@ export default class RoundInformation extends Vue {
         },
       },
     )
-  }
-
-  get filteredProjects(): Project[] {
-    return this.projects.filter((project: Project) => {
-      if (!this.search) {
-        return true
-      }
-      return project.name.toLowerCase().includes(this.search.toLowerCase())
-    })
   }
 }
 </script>


### PR DESCRIPTION
WIP fixes on #95 

@samajammin @wackerow need some help adding the round totals together...

![image](https://user-images.githubusercontent.com/40891631/120635286-3468f700-c464-11eb-861e-2cbb5a0bb7b8.png)
It currently just puts the numbers one after the other...

Fixed the duplicate round status in #95 (pictured below) in #107 
![image](https://user-images.githubusercontent.com/40891631/120477939-3bc8cb80-c3a4-11eb-8c88-9edec8e4f0f8.png)
