### PR TITLE
Hide cart input when round is over

### DIFF
--- a/vue-app/src/components/ProjectListItem.vue
+++ b/vue-app/src/components/ProjectListItem.vue
@@ -35,33 +35,33 @@
           Register
         </button>
 
-        <form action="#">
+        <form action="#" v-if="shouldShowCartInput">
           <!-- TODO: if a user is unconnected, adding to cart should trigger wallet connection -->
-        <div class="input-button">
-            <img style="margin-left: 0.5rem;" height="24px" v-if="!inCart" src="@/assets/dai.svg">
-            <input
-              v-model="amount"
-              class="input"
-              name="amount"
-              :placeholder="defaultContributionAmount"
-              autocomplete="on"
-              onfocus="this.value=''"
-              v-if="!inCart"
-            >
-            <input type="submit"
-              v-if="hasContributeBtn() && !inCart"
-              class="donate-btn"
-              :disabled="!canContribute()"
-              @click="contribute()"
-              value="Add to cart"
-            >
-            <div 
-              v-if="hasContributeBtn() && inCart"
-              class="donate-btn-full"
-            >
-            In cart 🎉
-            </div>
-        </div>
+          <div class="input-button">
+              <img style="margin-left: 0.5rem;" height="24px" v-if="!inCart" src="@/assets/dai.svg">
+              <input
+                v-model="amount"
+                class="input"
+                name="amount"
+                :placeholder="defaultContributionAmount"
+                autocomplete="on"
+                onfocus="this.value=''"
+                v-if="!inCart"
+              >
+              <input type="submit"
+                v-if="hasContributeBtn() && !inCart"
+                class="donate-btn"
+                :disabled="!canContribute()"
+                @click="contribute()"
+                value="Add to cart"
+              >
+              <div 
+                v-if="hasContributeBtn() && inCart"
+                class="donate-btn-full"
+              >
+              In cart 🎉
+              </div>
+          </div>
         </form>
 
         <!-- <button
@@ -126,6 +126,11 @@ export default class ProjectListItem extends Vue {
       return item.id === this.project.id && !item.isCleared
     })
     return index !== -1
+  }
+
+  get shouldShowCartInput(): boolean {
+    const { isRoundContributionPhase, canUserReallocate } = this.$store.getters
+    return isRoundContributionPhase || canUserReallocate
   }
 
   hasRegisterBtn(): boolean {

--- a/vue-app/src/views/Project.vue
+++ b/vue-app/src/views/Project.vue
@@ -24,31 +24,34 @@
         >
           Register
         </button>
-        <div class="input-button" v-if="hasContributeBtn() && !inCart">
-          <img style="margin-left: 0.5rem;" height="24px" src="@/assets/dai.svg">
-          <input
-            v-model="contributionAmount"
-            class="input"
-            name="contributionAmount"
-            placeholder="5"
-            autocomplete="on"
-            onfocus="this.value=''"
 
-          >
-          <input type="submit"
-            class="donate-btn"
-            :disabled="!canContribute()"
-            @click="contribute()"
-            value="Add to cart"
-          >
+        <div v-if="shouldShowCartInput">
+          <div class="input-button" v-if="hasContributeBtn() && !inCart">
+            <img style="margin-left: 0.5rem;" height="24px" src="@/assets/dai.svg">
+            <input
+              v-model="contributionAmount"
+              class="input"
+              name="contributionAmount"
+              placeholder="5"
+              autocomplete="on"
+              onfocus="this.value=''"
+            >
+            <input type="submit"
+              class="donate-btn"
+              :disabled="!canContribute()"
+              @click="contribute()"
+              value="Add to cart"
+            >
+          </div>
+          <div class="input-button" v-if="hasContributeBtn() && inCart">
+            <button
+              class="donate-btn-full"
+            >
+              <span>In cart 🎉</span>
+            </button>
+          </div>
         </div>
-        <div class="input-button" v-if="hasContributeBtn() && inCart">
-          <button
-            class="donate-btn-full"
-          >
-            <span>In cart 🎉</span>
-          </button>
-        </div>
+
         <!-- TODO: EXTRACT INTO COMPONENT: INPUT BUTTON -->
         <button
           v-if="hasClaimBtn()"
@@ -232,6 +235,11 @@ export default class ProjectView extends Vue {
 
   get isCartToggledOpen(): boolean {
     return this.$store.state.showCartPanel
+  }
+
+  get shouldShowCartInput(): boolean {
+    const { isRoundContributionPhase, canUserReallocate } = this.$store.getters
+    return isRoundContributionPhase || canUserReallocate
   }
 
   hasRegisterBtn(): boolean {


### PR DESCRIPTION
Only display the cart input when the user can make a contribution or reallocation.