### PR TITLE
MP reallocation copy change

### DIFF
--- a/vue-app/src/components/Cart.vue
+++ b/vue-app/src/components/Cart.vue
@@ -81,7 +81,7 @@
         {{ errorMessage }}
       </div>
       <div class="p1" v-if="hasUnallocatedFunds()">
-        Unallocated funds ({{ formatAmount(this.contribution) - formatAmount(getTotal())}} {{ tokenSymbol }}) will be sent to the matching pool.
+        Funds you don't contribute to projects ({{ formatAmount(this.contribution) - formatAmount(getTotal())}} {{ tokenSymbol }}) will be sent to the matching pool at the end of the round.
         Your cart must add up to your original {{ formatAmount(this.contribution) }} {{tokenSymbol}} donation.
       </div>
       <!-- <div v-if="canRegisterWithBrightId" @click="registerWithBrightId()" class="btn-primary"> -->


### PR DESCRIPTION
just a quick copy change to hopefully make it slightly clearer that any funds sent to the MP during reallocation won't go until the end of the round so users won't expect to see matching pool total increase immediately.