### PR TITLE
Mobile Landing page horizontal overflow fix

### DIFF
--- a/vue-app/src/components/RoundStatusBanner.vue
+++ b/vue-app/src/components/RoundStatusBanner.vue
@@ -63,6 +63,7 @@ export default class RoundStatusBanner extends Vue {
   position: relative;
   z-index: 1;
   width: 100%;
+  max-width: 100vw;
   background: $bg-primary-color;
   overflow: hidden;
   white-space: nowrap;

--- a/vue-app/src/views/Landing.vue
+++ b/vue-app/src/views/Landing.vue
@@ -161,7 +161,7 @@ export default class Landing extends Vue {
 #page > div {  
   padding: $content-space (2 * $content-space);
   @media (max-width: $breakpoint-m) {
-    padding: $content-space
+    padding: $content-space;
   }
 }
 


### PR DESCRIPTION
Places a max-width of `100vw` on the `round-status-banner` component to restore mobile responsiveness on landing page. 