### PR TITLE
Moves reallocation message above title in cart

### DIFF
--- a/vue-app/src/components/Cart.vue
+++ b/vue-app/src/components/Cart.vue
@@ -6,6 +6,9 @@
     <wallet-widget :isActionButton="true" />
   </div>
   <div v-else class="cart-container">
+    <div class="reallocation-message" v-if="$store.getters.canUserReallocate">
+        You’ve already contributed this round. You can edit your choices and add new projects, but your cart total must always equal your original contribution amount. <router-link to="/about-maci" class="message-link">Why?</router-link>
+      </div>
     <div class="flex cart-title-bar">
       <div v-if="showCollapseCart" @click="toggleCart" class="absolute-left cart-btn">
         <img
@@ -19,7 +22,7 @@
           src="@/assets/chevron-right.svg"
         >
       </div>
-      <h2>Your cart</h2>
+      <h2>{{editModeSelection ? "Edit cart" : "Your cart"}}</h2>
       <div v-if="($store.getters.isRoundContributionPhase || $store.getters.canUserReallocate) && !isCartEmpty" class="absolute-right dropdown">
         <img @click="openDropdown" class="dropdown-btn" src="@/assets/more.svg" />
         <div id="cart-dropdown" class="button-menu">
@@ -31,9 +34,6 @@
       </div>
     </div>
     <div class="messages-and-cart-items">
-      <div class="reallocation-intro" v-if="$store.getters.canUserReallocate">
-        You’ve already contributed this round. You can edit your choices and add new projects, but your cart total must always equal your original contribution amount. <router-link to="/about-maci">Why?</router-link>
-      </div>
       <div class="reallocation-intro" v-if="$store.getters.hasUserContributed && $store.getters.hasReallocationPhaseEnded">
         This round is over. Here’s how you contributed. Thanks!
       </div>
@@ -599,6 +599,7 @@ h2 {
   padding: 1rem 0rem;
   padding-top: 0rem;
   width: 100%;
+  border-left: 1px solid #000;
 
   @media (max-width: $breakpoint-m) {
     padding: 0rem;
@@ -780,6 +781,16 @@ h2 {
   margin-right: 1rem;
 }
 
+.reallocation-message {
+  padding: 1rem;
+  background: $highlight-color;
+  font-size: 14px;
+}
+
+.message-link {
+  color: #fff;
+  text-decoration: underline;
+}
 
 .balance {
   padding: 1rem;

--- a/vue-app/src/components/Cart.vue
+++ b/vue-app/src/components/Cart.vue
@@ -51,11 +51,12 @@
         </div>
         <div v-else-if="$store.getters.canUserReallocate && !isCartEmpty">
           <div class="flex-row-reallocation">
-            <div @click="handleEditState" v-if="$store.getters.canUserReallocate">
+            <div class="semi-bold">{{editModeSelection ? "Edit contributions" : "Your contributions"}}</div>
+            <div class="semi-bold" @click="handleEditState" v-if="$store.getters.canUserReallocate">
               <span v-if="editModeSelection">Cancel</span>
               <span v-else>Edit</span>
             </div>
-            <div @click="removeAll" v-if="$store.getters.canUserReallocate">Remove all</div>
+            <!-- <div @click="removeAll" v-if="$store.getters.canUserReallocate">Remove all</div> -->
           </div>
         </div>
         <div v-else-if="$store.getters.hasUserContributed" class="flex-row-reallocation" id="readOnly">
@@ -673,6 +674,14 @@ h2 {
   justify-content: space-between;
   align-items: center;
   padding: 0rem 1rem;
+}
+
+.semi-bold {
+  font-weight: 500;
+  font-size: 14px;
+  span {
+    text-decoration: underline;
+  }
 }
 
 .flex {


### PR DESCRIPTION
As per designs in #103 this PR moves the reallocation message above the cart tile and actions so that smart actions like Remove All and Split Evenly still feel related to the cart. I also added a conditional to change title to "Edit cart" when in edit mode.

It also updates the title above the project items to get in line with the design. 
