### PR TITLE
Pre-round information

### DIFF
--- a/vue-app/src/components/RoundInformation.vue
+++ b/vue-app/src/components/RoundInformation.vue
@@ -24,8 +24,21 @@
             Open
           </div>
         </div>
+        <div class="round-info-item" v-if="$store.getters.isRoundJoinPhase">
+          <div style="width: 100%">
+            <div style="width: 100%; display: flex; gap: 0.5rem">
+              <div class="round-info-title">⏱️ Round opening</div>
+            </div>
+          </div>
+          <div class="round-info-value">
+            <div class="value">{{ joinTimeLeft.days }}</div>
+            <div class="unit">days</div>
+            <div class="value">{{ joinTimeLeft.hours }}</div>
+            <div class="unit">hours</div>
+          </div>
+        </div>
         <div
-          v-if="
+          v-else-if="
             $store.getters.isRoundContributionPhase &&
             !$store.getters.hasUserContributed
           "
@@ -257,7 +270,16 @@
         </div>
       </template>
       <template v-else-if="!currentRound && !isLoading">
-        TODO: Add copy for pre-round status
+        <div class="round-info-item">
+          <div style="width: 100%">
+            <div style="width: 100%; display: flex; gap: 0.5rem">
+              <div class="round-info-title">No scheduled round</div>
+            </div>
+          </div>
+          <div class="round-info-value">
+            <!-- TODO: add no schedule round description -->
+          </div>
+        </div>
       </template>
       <loader v-if="isLoading" />
     </div>
@@ -367,6 +389,10 @@ export default class RoundInformation extends Vue {
 
   get currentRound(): RoundInfo | null {
     return this.$store.state.currentRound
+  }
+
+  get joinTimeLeft(): TimeLeft {
+    return getTimeLeft(this.$store.getters.recipientJoinDeadline)
   }
 
   get contributionTimeLeft(): TimeLeft {

--- a/vue-app/src/components/RoundInformation.vue
+++ b/vue-app/src/components/RoundInformation.vue
@@ -24,7 +24,13 @@
             Open
           </div>
         </div>
-        <div class="round-info-item" v-if="$store.getters.isRoundJoinPhase">
+        <div
+          class="round-info-item"
+          v-if="
+            $store.getters.isRoundJoinPhase &&
+            !$store.getters.isRoundContributionPhase
+          "
+        >
           <div style="width: 100%">
             <div style="width: 100%; display: flex; gap: 0.5rem">
               <div class="round-info-title">⏱️ Round opening</div>

--- a/vue-app/src/components/RoundInformation.vue
+++ b/vue-app/src/components/RoundInformation.vue
@@ -19,18 +19,13 @@
               ><div class="verified"><img src="@/assets/verified.svg" /></div
             ></tooltip>
           </div>
+          <!-- TODO add logic to status -->
           <div class="status">
             <div class="circle pulse open" />
             Open
           </div>
         </div>
-        <div
-          class="round-info-item"
-          v-if="
-            $store.getters.isRoundJoinPhase &&
-            !$store.getters.isRoundContributionPhase
-          "
-        >
+        <div class="round-info-item" v-if="$store.getters.isRoundJoinOnlyPhase">
           <div style="width: 100%">
             <div style="width: 100%; display: flex; gap: 0.5rem">
               <div class="round-info-title">⏱️ Round opening</div>
@@ -283,7 +278,7 @@
             </div>
           </div>
           <div class="round-info-value">
-            <!-- TODO: add no schedule round description -->
+            We haven't yet scheduled a funding round. Stay tuned!
           </div>
         </div>
       </template>


### PR DESCRIPTION
Fix #87 and #173

What we are seeing now in the no-round state:
![noround](https://user-images.githubusercontent.com/468158/123821799-0da4c000-d93f-11eb-918d-d3798758420a.png)