### PR TITLE
Join page content flickering

### DIFF
--- a/vue-app/src/views/JoinLanding.vue
+++ b/vue-app/src/views/JoinLanding.vue
@@ -9,7 +9,7 @@
     <round-status-banner />
     <back-to-projects :alsoShowOnMobile="true" />
 
-    <div class="content" v-if="isLoading">
+    <div class="content" v-if="isLoading || !$store.state.currentRound">
       <h1>Fetching round data...</h1>
       <loader />
     </div>


### PR DESCRIPTION
On the first load of the page or when the user refreshes the page, you can see a flickering in the content. That is because the round was not loaded yet. So, I've added it here.

https://user-images.githubusercontent.com/468158/123980808-2e374d80-da05-11eb-89dd-22b1ae44b09f.mp4