### PR TITLE
Moves metaInfo into router/index.ts [Closes #82]

### DIFF
--- a/vue-app/src/components/RoundInformation.vue
+++ b/vue-app/src/components/RoundInformation.vue
@@ -334,8 +334,6 @@ function shuffleArray(array: any[]) {
 }
 
 @Component({
-  name: 'round-info',
-  metaInfo: { title: 'Round' },
   components: {
     ProjectListItem,
     Loader,

--- a/vue-app/src/router/index.ts
+++ b/vue-app/src/router/index.ts
@@ -28,7 +28,7 @@ const routes = [
     path: '/',
     name: 'landing',
     component: Landing,
-    metaInfo: {
+    meta: {
       title: 'Eth2 clr.fund',
     },
   },
@@ -36,7 +36,7 @@ const routes = [
     path: '/projects',
     name: 'projects',
     component: ProjectList,
-    metaInfo: {
+    meta: {
       title: 'Project List',
     },
   },
@@ -49,7 +49,7 @@ const routes = [
     path: '/round-information',
     name: 'round-information',
     component: RoundInformation,
-    metaInfo: {
+    meta: {
       title: 'Round Information',
     },
   },
@@ -57,7 +57,7 @@ const routes = [
     path: '/rounds',
     name: 'rounds',
     component: RoundList,
-    metaInfo: {
+    meta: {
       title: 'Rounds',
     },
   },
@@ -65,7 +65,7 @@ const routes = [
     path: '/round/:address',
     name: 'round',
     component: ProjectList,
-    metaInfo: {
+    meta: {
       title: 'Project List for Round',
     },
   },
@@ -73,7 +73,7 @@ const routes = [
     path: '/about',
     name: 'about',
     component: About,
-    metaInfo: {
+    meta: {
       title: 'About',
     },
   },
@@ -81,7 +81,7 @@ const routes = [
     path: '/about-maci',
     name: 'about-maci',
     component: AboutMaci,
-    metaInfo: {
+    meta: {
       title: 'About MACI',
     },
   },
@@ -89,7 +89,7 @@ const routes = [
     path: '/about-sybil-attacks',
     name: 'about-sybil-attacks',
     component: AboutSybilAttacks,
-    metaInfo: {
+    meta: {
       title: 'About Sybil Attacks',
     },
   },
@@ -97,7 +97,7 @@ const routes = [
     path: '/about-layer2',
     name: 'about-layer-2',
     component: AboutLayer2,
-    metaInfo: {
+    meta: {
       title: 'About Layer 2',
     },
   },
@@ -105,7 +105,7 @@ const routes = [
     path: '/how-it-works',
     name: 'how-it-works',
     component: HowItWorks,
-    metaInfo: {
+    meta: {
       title: 'How it works',
     },
   },
@@ -113,7 +113,7 @@ const routes = [
     path: '/recipients',
     name: 'recipients',
     component: RecipientRegistryView,
-    metaInfo: {
+    meta: {
       title: 'Recipient registry',
     },
   },
@@ -121,7 +121,7 @@ const routes = [
     path: '/verify',
     name: 'verify',
     component: VerifyLanding,
-    metaInfo: {
+    meta: {
       title: 'BrightID Verify Landing',
     },
   },
@@ -129,7 +129,7 @@ const routes = [
     path: '/verify/success',
     name: 'verified',
     component: Verified,
-    metaInfo: {
+    meta: {
       title: 'Verified',
     },
   },
@@ -137,7 +137,7 @@ const routes = [
     path: '/verify/:step',
     name: 'verify-step',
     component: VerifyView,
-    metaInfo: {
+    meta: {
       title: 'Verification Steps',
     },
   },
@@ -145,7 +145,7 @@ const routes = [
     path: '/join',
     name: 'join',
     component: JoinLanding,
-    metaInfo: {
+    meta: {
       title: 'Recipient Join Form Landing',
     },
   },
@@ -153,7 +153,7 @@ const routes = [
     path: '/join/success',
     name: 'project-added',
     component: ProjectAdded,
-    metaInfo: {
+    meta: {
       title: 'Recipient Join Form Success',
     },
   },
@@ -161,7 +161,7 @@ const routes = [
     path: '/join/:step',
     name: 'join-step',
     component: JoinView,
-    metaInfo: {
+    meta: {
       title: 'Recipient Join Form Steps',
     },
   },
@@ -169,7 +169,7 @@ const routes = [
     path: '/sybil-resistance',
     name: 'sybil-resistance',
     component: AboutSybilResistance,
-    metaInfo: {
+    meta: {
       title: 'Sybil Resistance',
     },
   },
@@ -177,7 +177,7 @@ const routes = [
     path: '/cart',
     name: 'cart',
     component: CartView,
-    metaInfo: {
+    meta: {
       title: 'Cart',
     },
   },

--- a/vue-app/src/router/index.ts
+++ b/vue-app/src/router/index.ts
@@ -28,11 +28,17 @@ const routes = [
     path: '/',
     name: 'landing',
     component: Landing,
+    metaInfo: {
+      title: 'Eth2 clr.fund',
+    },
   },
   {
     path: '/projects',
     name: 'projects',
     component: ProjectList,
+    metaInfo: {
+      title: 'Project List',
+    },
   },
   {
     path: '/project/:id',
@@ -43,86 +49,137 @@ const routes = [
     path: '/round-information',
     name: 'round-information',
     component: RoundInformation,
+    metaInfo: {
+      title: 'Round Information',
+    },
   },
   {
     path: '/rounds',
     name: 'rounds',
     component: RoundList,
+    metaInfo: {
+      title: 'Rounds',
+    },
   },
   {
     path: '/round/:address',
     name: 'round',
     component: ProjectList,
+    metaInfo: {
+      title: 'Project List for Round',
+    },
   },
   {
     path: '/about',
     name: 'about',
     component: About,
+    metaInfo: {
+      title: 'About',
+    },
   },
   {
     path: '/about-maci',
     name: 'about-maci',
     component: AboutMaci,
+    metaInfo: {
+      title: 'About MACI',
+    },
   },
   {
-    path: '/about-sybil-resistance',
-    name: 'about-sybil-resistance',
+    path: '/about-sybil-attacks',
+    name: 'about-sybil-attacks',
     component: AboutSybilAttacks,
+    metaInfo: {
+      title: 'About Sybil Attacks',
+    },
   },
   {
     path: '/about-layer2',
     name: 'about-layer-2',
     component: AboutLayer2,
+    metaInfo: {
+      title: 'About Layer 2',
+    },
   },
   {
     path: '/how-it-works',
     name: 'how-it-works',
     component: HowItWorks,
+    metaInfo: {
+      title: 'How it works',
+    },
   },
   {
     path: '/recipients',
     name: 'recipients',
     component: RecipientRegistryView,
+    metaInfo: {
+      title: 'Recipient registry',
+    },
   },
   {
     path: '/verify',
     name: 'verify',
     component: VerifyLanding,
+    metaInfo: {
+      title: 'BrightID Verify Landing',
+    },
   },
   {
     path: '/verify/success',
     name: 'verified',
     component: Verified,
+    metaInfo: {
+      title: 'Verified',
+    },
   },
   {
     path: '/verify/:step',
     name: 'verify-step',
     component: VerifyView,
+    metaInfo: {
+      title: 'Verification Steps',
+    },
   },
   {
     path: '/join',
     name: 'join',
     component: JoinLanding,
+    metaInfo: {
+      title: 'Recipient Join Form Landing',
+    },
   },
   {
     path: '/join/success',
     name: 'project-added',
     component: ProjectAdded,
+    metaInfo: {
+      title: 'Recipient Join Form Success',
+    },
   },
   {
     path: '/join/:step',
     name: 'join-step',
     component: JoinView,
+    metaInfo: {
+      title: 'Recipient Join Form Steps',
+    },
   },
   {
     path: '/sybil-resistance',
     name: 'sybil-resistance',
     component: AboutSybilResistance,
+    metaInfo: {
+      title: 'Sybil Resistance',
+    },
   },
   {
     path: '/cart',
     name: 'cart',
     component: CartView,
+    metaInfo: {
+      title: 'Cart',
+    },
   },
 ]
 const router = new VueRouter({

--- a/vue-app/src/views/About.vue
+++ b/vue-app/src/views/About.vue
@@ -90,10 +90,7 @@
 import Vue from 'vue'
 import Component from 'vue-class-component'
 
-@Component({
-  name: 'about',
-  metaInfo: { title: 'About' },
-})
+@Component
 export default class About extends Vue {}
 </script>
 

--- a/vue-app/src/views/AboutLayer2.vue
+++ b/vue-app/src/views/AboutLayer2.vue
@@ -37,10 +37,7 @@
 import Vue from 'vue'
 import Component from 'vue-class-component'
 
-@Component({
-  name: 'about-layer2',
-  metaInfo: { title: 'About Layer 2' },
-})
+@Component
 export default class AboutLayer2 extends Vue {}
 </script>
 

--- a/vue-app/src/views/AboutMaci.vue
+++ b/vue-app/src/views/AboutMaci.vue
@@ -99,10 +99,7 @@
 import Vue from 'vue'
 import Component from 'vue-class-component'
 
-@Component({
-  name: 'about-maci',
-  metaInfo: { title: 'About Maci' },
-})
+@Component
 export default class AboutMaci extends Vue {}
 </script>
 

--- a/vue-app/src/views/AboutSybilAttacks.vue
+++ b/vue-app/src/views/AboutSybilAttacks.vue
@@ -81,10 +81,7 @@
 import Vue from 'vue'
 import Component from 'vue-class-component'
 
-@Component({
-  name: 'about-sybil-resistance',
-  metaInfo: { title: 'About Sybil Resistance' },
-})
+@Component
 export default class AboutSybilAttacks extends Vue {}
 </script>
 

--- a/vue-app/src/views/AboutSybilResistance.vue
+++ b/vue-app/src/views/AboutSybilResistance.vue
@@ -90,10 +90,7 @@
 import Vue from 'vue'
 import Component from 'vue-class-component'
 
-@Component({
-  name: 'sybil-resistance',
-  metaInfo: { title: 'Sybil Resistance' },
-})
+@Component
 export default class AboutSybilResistance extends Vue {}
 </script>
 

--- a/vue-app/src/views/HowItWorks.vue
+++ b/vue-app/src/views/HowItWorks.vue
@@ -133,9 +133,7 @@ import Vue from 'vue'
 import Component from 'vue-class-component'
 
 // TODO connect with state to add durations to content
-@Component({
-  metaInfo: { title: 'How it works' },
-})
+@Component
 export default class HowItWorks extends Vue {}
 </script>
 

--- a/vue-app/src/views/Project.vue
+++ b/vue-app/src/views/Project.vue
@@ -89,7 +89,6 @@ import { SET_RECIPIENT_REGISTRY_ADDRESS } from '@/store/mutation-types'
 import { markdown } from '@/utils/markdown'
 
 @Component({
-  name: 'ProjectView',
   metaInfo() {
     return { title: (this as any).project?.name || '' }
   },

--- a/vue-app/src/views/RecipientRegistry.vue
+++ b/vue-app/src/views/RecipientRegistry.vue
@@ -107,13 +107,7 @@ import { SET_RECIPIENT_REGISTRY_ADDRESS } from '@/store/mutation-types'
 import { formatAmount } from '@/utils/amounts'
 import { markdown } from '@/utils/markdown'
 
-@Component({
-  name: 'recipient-registry',
-  metaInfo() {
-    return { title: 'Recipient registry' }
-  },
-  components: { Loader },
-})
+@Component({ components: { Loader } })
 export default class RecipientRegistryView extends Vue {
   registryInfo: RegistryInfo | null = null
   requests: Request[] = []

--- a/vue-app/src/views/RoundList.vue
+++ b/vue-app/src/views/RoundList.vue
@@ -20,10 +20,7 @@ import Component from 'vue-class-component'
 
 import { Round, getRounds } from '@/api/rounds'
 
-@Component({
-  name: 'round-list',
-  metaInfo: { title: 'Rounds' },
-})
+@Component
 export default class RoundList extends Vue {
   rounds: Round[] = []
 

--- a/vue-app/src/views/Verified.vue
+++ b/vue-app/src/views/Verified.vue
@@ -51,11 +51,7 @@ import {
 } from '@/api/recipient-registry-optimistic'
 import { blockExplorer } from '@/api/core'
 
-@Component({
-  name: 'verified',
-  metaInfo: { title: 'verified' },
-  components: { ProgressBar, RoundStatusBanner },
-})
+@Component({ components: { ProgressBar, RoundStatusBanner } })
 export default class Verified extends Vue {
   challengePeriodDuration: number | null = null
   startDate = '03 April' // TODO: use Date() object


### PR DESCRIPTION
Assigns a metaInfo title to each view in `router/index.ts`, removing these from individual components.

Exception is `Project.vue` where it pulls name of project passed in path and assigns to metaInfo