### PR TITLE
Adds max size for join hero [Fixes #14]

### DIFF
--- a/vue-app/src/views/JoinLanding.vue
+++ b/vue-app/src/views/JoinLanding.vue
@@ -241,9 +241,11 @@ h1 {
     img {
       position: absolute;
       bottom: 0;
-      right: -128px;
+      right: calc(-700px + 50vw);
       mix-blend-mode: exclusion;
-      width: 88%;
+      max-width: 88%;
+      max-height: 100%;
+
       @media (max-width: ($breakpoint-m)) {
         right: 1rem;
         width: 100%;


### PR DESCRIPTION
Join landing: Limits overflow of hero images on XL screens. Adjusts right positioning to add expanding buffer on right side of image on XL screens.

Note, the original issue (#14) also mentioned the main landing page hero, which has already been addressed for overflow, and the wormhole image, which is planned to be replaced and was not touched here.