### PR TITLE
Increases horizontal margins on forms [Fixes #18]

### DIFF
--- a/vue-app/src/views/Join.vue
+++ b/vue-app/src/views/Join.vue
@@ -1009,7 +1009,7 @@ export default class JoinView extends mixins(validationMixin) {
 @import '../styles/theme';
 
 .container {
-  width: clamp(calc(800px - 4rem), calc(100% - 4rem), 1440px);
+  width: clamp(calc(800px - 4rem), calc(100% - 4rem), 1100px);
   margin: 0 auto;
   @media (max-width: $breakpoint-m) {
     width: 100%;

--- a/vue-app/src/views/Verify.vue
+++ b/vue-app/src/views/Verify.vue
@@ -622,7 +622,7 @@ export default class VerifyView extends mixins(validationMixin) {
 @import '../styles/theme';
 
 .container {
-  width: clamp(calc(800px - 4rem), calc(100% - 4rem), 1440px);
+  width: clamp(calc(800px - 4rem), calc(100% - 4rem), 1100px);
   margin: 0 auto;
   @media (max-width: $breakpoint-m) {
     width: 100%;


### PR DESCRIPTION
Per #18, design showing greater limitations on the max-width of the join and verify forms.

These were previously set at a max-width of 1440px. This PR drops this to 1100px for readability on larger screens. 