### PR TITLE
Extracts reusable LinkBox component

### DIFF
--- a/vue-app/src/components/LinkBox.vue
+++ b/vue-app/src/components/LinkBox.vue
@@ -1,0 +1,55 @@
+<template>
+  <div class="link-box">
+    <h2 class="link-title">Check them out</h2>
+    <div v-if="project.githubUrl" class="link-row">
+      <img src="@/assets/GitHub.svg" />
+      <a :href="project.githubUrl">GitHub repo</a>
+    </div>
+    <div v-if="project.twitterUrl" class="link-row">
+      <img src="@/assets/Twitter.svg" />
+      <a :href="project.twitterUrl">@Twitter</a>
+    </div>
+    <div v-if="project.websiteUrl" class="link-row">
+      <img src="@/assets/Meridians.svg" />
+      <a :href="project.websiteUrl">{{ project.websiteUrl }}</a>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import Vue from 'vue'
+import Component from 'vue-class-component'
+import { Prop } from 'vue-property-decorator'
+import { Project } from '@/api/projects'
+
+@Component
+export default class extends Vue {
+  @Prop() project!: Project
+}
+</script>
+
+<style scoped lang="scss">
+@import '../styles/vars';
+@import '../styles/theme';
+
+.link-box {
+  background: $bg-primary-color;
+  padding: 1.5rem;
+  border-radius: 1rem;
+  box-shadow: $box-shadow;
+
+  .link-title {
+    font-size: 1.5rem;
+    margin: 0;
+    margin-bottom: 1rem;
+    font-family: 'Glacial Indifference', sans-serif;
+  }
+
+  .link-row {
+    display: flex;
+    align-items: center;
+    padding: 0.5rem;
+    gap: 0.5rem;
+  }
+}
+</style>

--- a/vue-app/src/components/ProjectProfile.vue
+++ b/vue-app/src/components/ProjectProfile.vue
@@ -119,21 +119,7 @@
         <markdown :raw="project.teamDescription" />
       </div>
     </div>
-    <div v-if="previewMode">
-      <h2 class="link-title">Check them out</h2>
-      <div v-if="project.githubUrl" class="link-row">
-        <img src="@/assets/GitHub.svg" />
-        <a :href="project.githubUrl">GitHub repo</a>
-      </div>
-      <div v-if="project.twitterUrl" class="link-row">
-        <img src="@/assets/Twitter.svg" />
-        <a :href="project.twitterUrl">@Twitter</a>
-      </div>
-      <div v-if="project.websiteUrl" class="link-row">
-        <img src="@/assets/Meridians.svg" />
-        <a :href="project.websiteUrl">{{ project.websiteUrl }}</a>
-      </div>
-    </div>
+    <link-box v-if="previewMode" :project="project" class="mt2" />
   </div>
 </template>
 
@@ -153,13 +139,9 @@ import { RoundStatus } from '@/api/round'
 import { SAVE_CART } from '@/store/action-types'
 import { ADD_CART_ITEM } from '@/store/mutation-types'
 import ClaimModal from '@/components/ClaimModal.vue'
+import LinkBox from '@/components/LinkBox.vue'
 
-@Component({
-  components: {
-    Markdown,
-    Info,
-  },
-})
+@Component({ components: { Markdown, Info, LinkBox } })
 export default class ProjectProfile extends Vue {
   allocatedAmount: FixedNumber | null = null
   contributionAmount: number | null = DEFAULT_CONTRIBUTION_AMOUNT
@@ -480,13 +462,6 @@ export default class ProjectProfile extends Vue {
     }
   }
 
-  .link-row {
-    display: flex;
-    align-items: center;
-    padding: 0.5rem;
-    gap: 0.5rem;
-  }
-
   .input-button {
     background: #f7f7f7;
     border-radius: 2rem;
@@ -547,6 +522,10 @@ export default class ProjectProfile extends Vue {
 
   .mb2 {
     margin-bottom: 2rem;
+  }
+
+  .mt2 {
+    margin-top: 2rem;
   }
 }
 </style>

--- a/vue-app/src/views/Project.vue
+++ b/vue-app/src/views/Project.vue
@@ -40,21 +40,7 @@
           <span>Contributed!</span>
         </button>
       </div>
-      <div class="link-box">
-        <h2 class="link-title">Check them out</h2>
-        <div v-if="project.githubUrl" class="link-row">
-          <img src="@/assets/GitHub.svg" />
-          <a :href="project.githubUrl">GitHub repo</a>
-        </div>
-        <div v-if="project.twitterUrl" class="link-row">
-          <img src="@/assets/Twitter.svg" />
-          <a :href="project.twitterUrl">@Twitter</a>
-        </div>
-        <div v-if="project.websiteUrl" class="link-row">
-          <img src="@/assets/Meridians.svg" />
-          <a :href="project.websiteUrl">{{ project.websiteUrl }}</a>
-        </div>
-      </div>
+      <link-box :project="project" />
     </div>
   </div>
 </template>
@@ -77,6 +63,7 @@ import ClaimModal from '@/components/ClaimModal.vue'
 import Loader from '@/components/Loader.vue'
 import ProjectProfile from '@/components/ProjectProfile.vue'
 import AddToCartButton from '@/components/AddToCartButton.vue'
+import LinkBox from '@/components/LinkBox.vue'
 import {
   SELECT_ROUND,
   LOAD_ROUND_INFO,
@@ -93,7 +80,7 @@ import { markdown } from '@/utils/markdown'
   metaInfo() {
     return { title: (this as any).project?.name || '' }
   },
-  components: { Loader, ProjectProfile, AddToCartButton },
+  components: { Loader, ProjectProfile, AddToCartButton, LinkBox },
 })
 export default class ProjectView extends Vue {
   project: Project | null = null
@@ -382,34 +369,12 @@ export default class ProjectView extends Vue {
   line-height: 150%;
 }
 
-.link-box {
-  background: $bg-primary-color;
-  padding: 1.5rem;
-  /* min-width: 320px; */
-  border-radius: 16px;
-  box-shadow: $box-shadow;
-}
-
 .admin-box {
   background: $bg-primary-color;
   padding: 1.5rem;
   min-width: 320px;
   border-radius: 16px;
   border: 1px solid $error-color;
-}
-
-.link-title {
-  font-size: 24px;
-  margin: 0;
-  margin-bottom: 1rem;
-  font-family: 'Glacial Indifference', sans-serif;
-}
-
-.link-row {
-  display: flex;
-  align-items: center;
-  padding: 0.5rem;
-  gap: 0.5rem;
 }
 
 .project-name {


### PR DESCRIPTION
- Render GitHub/Twitter/Website links for a project as it previously did, extracted into reusable component
- Accepts a `Project` as a prop
- Used in `Project` and `ProjectProfile`