### PR TITLE
Make remove recipient onlyowner

### DIFF
--- a/contracts/contracts/recipientRegistry/OptimisticRecipientRegistry.sol
+++ b/contracts/contracts/recipientRegistry/OptimisticRecipientRegistry.sol
@@ -126,6 +126,7 @@ contract OptimisticRecipientRegistry is Ownable, BaseRecipientRegistry {
     */
   function removeRecipient(bytes32 _recipientId)
     external
+    onlyOwner
     payable
   {
     require(recipients[_recipientId].index != 0, 'RecipientRegistry: Recipient is not in the registry');


### PR DESCRIPTION
From the UI we are already only allowing the admin/owner to remove a project. This is to add the verification in the contract.

https://www.notion.so/efdn/Restrict-project-removals-to-admin-only-82baf36ae696473a8228f899a98a51eb