### PR TITLE
Add wait() to deploy txs

### DIFF
--- a/contracts/scripts/deploy.ts
+++ b/contracts/scripts/deploy.ts
@@ -22,7 +22,10 @@ async function main() {
   await fundingRoundFactory.deployTransaction.wait()
   console.log(`FundingRoundFactory deployed: ${fundingRoundFactory.address}`)
 
-  await maciFactory.transferOwnership(fundingRoundFactory.address)
+  const transferOwnershipTx = await maciFactory.transferOwnership(
+    fundingRoundFactory.address
+  )
+  await transferOwnershipTx.wait()
 
   const userRegistryType = process.env.USER_REGISTRY_TYPE || 'simple'
   let userRegistry: Contract
@@ -48,7 +51,10 @@ async function main() {
   await userRegistry.deployTransaction.wait()
   console.log(`User registry deployed: ${userRegistry.address}`)
 
-  await fundingRoundFactory.setUserRegistry(userRegistry.address)
+  const setUserRegistryTx = await fundingRoundFactory.setUserRegistry(
+    userRegistry.address
+  )
+  await setUserRegistryTx.wait()
 
   const recipientRegistryType = process.env.RECIPIENT_REGISTRY_TYPE || 'simple'
   let recipientRegistry: Contract
@@ -76,7 +82,10 @@ async function main() {
   await recipientRegistry.deployTransaction.wait()
   console.log(`Recipient registry deployed: ${recipientRegistry.address}`)
 
-  await fundingRoundFactory.setRecipientRegistry(recipientRegistry.address)
+  const setRecipientRegistryTx = await fundingRoundFactory.setRecipientRegistry(
+    recipientRegistry.address
+  )
+  await setRecipientRegistryTx.wait()
   console.log(`Deployment complete!`)
 }
 

--- a/contracts/scripts/deploy.ts
+++ b/contracts/scripts/deploy.ts
@@ -6,8 +6,11 @@ import { deployMaciFactory } from '../utils/deployment'
 
 async function main() {
   const [deployer] = await ethers.getSigners()
+  console.log(`Deploying from address: ${deployer.address}`)
+
   const maciFactory = await deployMaciFactory(deployer)
   await maciFactory.deployTransaction.wait()
+  console.log(`MACIFactory deployed: ${maciFactory.address}`)
 
   const FundingRoundFactory = await ethers.getContractFactory(
     'FundingRoundFactory',
@@ -17,11 +20,9 @@ async function main() {
     maciFactory.address
   )
   await fundingRoundFactory.deployTransaction.wait()
+  console.log(`FundingRoundFactory deployed: ${fundingRoundFactory.address}`)
 
-  const transferReceipt = await maciFactory.transferOwnership(
-    fundingRoundFactory.address
-  )
-  await transferReceipt.wait()
+  await maciFactory.transferOwnership(fundingRoundFactory.address)
 
   const userRegistryType = process.env.USER_REGISTRY_TYPE || 'simple'
   let userRegistry: Contract
@@ -46,6 +47,7 @@ async function main() {
   }
   await userRegistry.deployTransaction.wait()
   console.log(`User registry deployed: ${userRegistry.address}`)
+
   await fundingRoundFactory.setUserRegistry(userRegistry.address)
 
   const recipientRegistryType = process.env.RECIPIENT_REGISTRY_TYPE || 'simple'
@@ -74,12 +76,8 @@ async function main() {
   await recipientRegistry.deployTransaction.wait()
   console.log(`Recipient registry deployed: ${recipientRegistry.address}`)
 
-  const setRecipientReceipt = await fundingRoundFactory.setRecipientRegistry(
-    recipientRegistry.address
-  )
-  await setRecipientReceipt.wait()
-
-  console.log(`Factory deployed: ${fundingRoundFactory.address}`)
+  await fundingRoundFactory.setRecipientRegistry(recipientRegistry.address)
+  console.log(`Deployment complete!`)
 }
 
 main()

--- a/contracts/scripts/deployTestRound.ts
+++ b/contracts/scripts/deployTestRound.ts
@@ -41,12 +41,14 @@ async function main() {
     'FundingRoundFactory',
     factoryAddress
   )
-  await factory.setToken(token.address)
+  const setTokenTx = await factory.setToken(token.address)
+  await setTokenTx.wait()
   const coordinatorKeyPair = new Keypair()
-  await factory.setCoordinator(
+  const setCoordinatorTx = await factory.setCoordinator(
     coordinator.getAddress(),
     coordinatorKeyPair.pubKey.asContractParam()
   )
+  await setCoordinatorTx.wait()
 
   // Configure MACI factory
   const maciFactoryAddress = await factory.maciFactory()
@@ -59,7 +61,10 @@ async function main() {
     signUpDuration: 60 * 5, // 5 minutes
     votingDuration: 60 * 5,
   })
-  await factory.setMaciParameters(...maciParameters.values())
+  const setMaciParametersTx = await factory.setMaciParameters(
+    ...maciParameters.values()
+  )
+  await setMaciParametersTx.wait()
 
   // Add to matching pool
   const poolContributionAmount = UNIT.mul(10)
@@ -340,7 +345,8 @@ async function main() {
   }
 
   // Deploy new funding round and MACI
-  await factory.deployNewRound()
+  const deployNewRoundTx = await factory.deployNewRound()
+  await deployNewRoundTx.wait()
   const fundingRoundAddress = await factory.getCurrentRound()
   console.log(`Funding round deployed: ${fundingRoundAddress}`)
   const fundingRound = await ethers.getContractAt(

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "test:contracts": "yarn workspace @clrfund/contracts run test",
     "test:web": "yarn workspace @clrfund/vue-app run test",
     "test:format": "yarn prettier --check",
-    "deploy:local": "yarn workspace @clrfund/contracts run deploy:local && yarn workspace @clrfund/contracts run deployTestRound:local",
+    "deploy:local": "yarn deploy:local-registry && yarn deploy:local-round",
     "deploy:local-registry": "yarn workspace @clrfund/contracts run deploy:local",
     "deploy:local-round": "yarn workspace @clrfund/contracts run deployTestRound:local",
     "upgrade:local": "yarn workspace @clrfund/contracts run upgrade:local",


### PR DESCRIPTION
Refactor deploy.ts script to properly wait for txs to execute.

Previously we were calling `await` on deploy txs (e.g. `const tx = await contract.deploy()` but that merely waits for promise to resolve for the tx receipt. In order to wait for the tx to execute / be confirmed, we need to add `await tx.deployTransaction.wait()`.