### PR TITLE
Brightid integration #1

### DIFF
--- a/vue-app/src/api/core.ts
+++ b/vue-app/src/api/core.ts
@@ -17,7 +17,15 @@ export const factory = new ethers.Contract(
   provider
 )
 export const userRegistryType = process.env.VUE_APP_USER_REGISTRY_TYPE
-if (!['simple', 'brightid'].includes(userRegistryType as string)) {
+export enum UserRegistryType {
+  BRIGHT_ID = 'brightid',
+  SIMPLE = 'simple',
+}
+if (
+  ![UserRegistryType.BRIGHT_ID, UserRegistryType.SIMPLE].includes(
+    userRegistryType as UserRegistryType
+  )
+) {
   throw new Error('invalid user registry type')
 }
 export const recipientRegistryType = process.env.VUE_APP_RECIPIENT_REGISTRY_TYPE

--- a/vue-app/src/api/user.ts
+++ b/vue-app/src/api/user.ts
@@ -8,17 +8,17 @@ import { BrightIdError, getVerification } from './bright-id'
 
 export const LOGIN_MESSAGE = `Sign this message to access clr.fund at ${factory.address.toLowerCase()}.`
 
-interface BrightId {
+export interface BrightId {
   isLinked: boolean
   isSponsored: boolean
   isVerified: boolean // If is verified in BrightID
-  isRegistered: boolean // If is in user registry
 }
 export interface User {
   walletAddress: string
   walletProvider: Web3Provider
   encryptionKey: string
   brightId: BrightId
+  isRegistered: boolean // If is in user registry
   balance?: BigNumber | null
   etherBalance?: BigNumber | null
   contribution?: BigNumber | null
@@ -61,57 +61,34 @@ export async function getEtherBalance(
   return await provider.getBalance(walletAddress)
 }
 
-export async function getBrightId(
-  userRegistryAddress: string,
-  walletAddress: string
-): Promise<BrightId> {
+export async function getBrightId(contextId: string): Promise<BrightId> {
   const brightId: BrightId = {
     isLinked: false,
     isSponsored: false,
     isVerified: false,
-    isRegistered: false,
   }
 
   try {
-    const isRegistered = await isVerifiedUser(
-      userRegistryAddress,
-      walletAddress
-    )
+    await getVerification(contextId)
+    brightId.isLinked = true
+    brightId.isSponsored = true
+    brightId.isVerified = true
+  } catch (error) {
+    if (!(error instanceof BrightIdError)) {
+      /* eslint-disable-next-line no-console */
+      console.error(error)
+    }
 
-    if (isRegistered) {
-      // If the user is in our registry is because he has been verifed before
+    // Not verified user
+    if (error.code === 3) {
       brightId.isLinked = true
       brightId.isSponsored = true
-      brightId.isVerified = true
-      brightId.isRegistered = true
-    } else {
-      // For not registered users, lets fetch the Bright ID status
-      try {
-        await getVerification(walletAddress)
-        brightId.isLinked = true
-        brightId.isSponsored = true
-        brightId.isVerified = true
-      } catch (error) {
-        if (error instanceof BrightIdError) {
-          // Not verified user
-          if (error.code === 3) {
-            brightId.isLinked = true
-            brightId.isSponsored = true
-          }
-
-          // Not sponsored user
-          if (error.code === 4) {
-            brightId.isLinked = true
-          }
-        }
-
-        /* eslint-disable-next-line no-console */
-        console.error(error)
-      }
     }
-  } catch (error) {
-    /* eslint-disable-next-line no-console */
-    console.error(error)
+
+    // Not sponsored user
+    if (error.code === 4) {
+      brightId.isLinked = true
+    }
   }
 
   return brightId

--- a/vue-app/src/components/CallToActionCard.vue
+++ b/vue-app/src/components/CallToActionCard.vue
@@ -50,7 +50,7 @@ import Component from 'vue-class-component'
 import BrightIdWidget from '@/components/BrightIdWidget.vue'
 
 import { TOGGLE_SHOW_CART_PANEL } from '@/store/mutation-types'
-import { userRegistryType } from '@/api/core'
+import { userRegistryType, UserRegistryType } from '@/api/core'
 
 @Component({
   components: {
@@ -74,7 +74,7 @@ export default class CallToActionCard extends Vue {
 
   get showUserVerification(): boolean {
     return (
-      userRegistryType === 'brightid' &&
+      userRegistryType === UserRegistryType.BRIGHT_ID &&
       (!this.isUserVerified || !this.isUserUnique)
     )
   }

--- a/vue-app/src/components/Cart.vue
+++ b/vue-app/src/components/Cart.vue
@@ -301,7 +301,11 @@ import {
   MAX_CART_SIZE,
   CartItem,
 } from '@/api/contributions'
-import { userRegistryType, provider as jsonRpcProvider } from '@/api/core'
+import {
+  userRegistryType,
+  provider as jsonRpcProvider,
+  UserRegistryType,
+} from '@/api/core'
 import { RoundStatus, TimeLeft } from '@/api/round'
 import { LOGOUT_USER, SAVE_CART } from '@/store/action-types'
 import { User } from '@/api/user'
@@ -575,7 +579,10 @@ export default class Cart extends Vue {
       return 'Please connect your wallet'
     } else if (currentUser.isVerified === null) {
       return '' // No error: waiting for verification check
-    } else if (!currentUser.isVerified && userRegistryType === 'brightid') {
+    } else if (
+      !currentUser.isVerified &&
+      userRegistryType === UserRegistryType.BRIGHT_ID
+    ) {
       return 'To contribute, you need to set up BrightID.'
     } else if (!this.isFormValid()) {
       return 'Include valid contribution amount.'
@@ -640,7 +647,7 @@ export default class Cart extends Vue {
 
   get canRegisterWithBrightId(): boolean {
     return (
-      userRegistryType === 'brightid' &&
+      userRegistryType === UserRegistryType.BRIGHT_ID &&
       !this.$store.state.currentUser?.isVerified
     )
   }

--- a/vue-app/src/components/WalletModal.vue
+++ b/vue-app/src/components/WalletModal.vue
@@ -37,7 +37,7 @@ import Component from 'vue-class-component'
 import { Prop } from 'vue-property-decorator'
 
 // API
-import { User, getProfileImageUrl } from '@/api/user'
+import { User, getProfileImageUrl, getBrightId } from '@/api/user'
 
 // Components
 import Loader from '@/components/Loader.vue'
@@ -86,6 +86,13 @@ export default class WalletModal extends Vue {
 
     const url = await getProfileImageUrl(user.walletAddress)
     this.updateProfileImage(url)
+
+    // Bright id verification
+    // TODO: move this to the store? to LOAD_USER_INFO?
+    user.brightId = await getBrightId(
+      this.$store.state.currentRound.userRegistryAddress,
+      user.walletAddress
+    )
 
     this.$store.commit(SET_CURRENT_USER, user)
     await this.$store.dispatch(LOGIN_USER)

--- a/vue-app/src/components/WalletModal.vue
+++ b/vue-app/src/components/WalletModal.vue
@@ -37,7 +37,7 @@ import Component from 'vue-class-component'
 import { Prop } from 'vue-property-decorator'
 
 // API
-import { User, getProfileImageUrl, getBrightId } from '@/api/user'
+import { User, getProfileImageUrl } from '@/api/user'
 
 // Components
 import Loader from '@/components/Loader.vue'
@@ -86,13 +86,6 @@ export default class WalletModal extends Vue {
 
     const url = await getProfileImageUrl(user.walletAddress)
     this.updateProfileImage(url)
-
-    // Bright id verification
-    // TODO: move this to the store? to LOAD_USER_INFO?
-    user.brightId = await getBrightId(
-      this.$store.state.currentRound.userRegistryAddress,
-      user.walletAddress
-    )
 
     this.$store.commit(SET_CURRENT_USER, user)
     await this.$store.dispatch(LOGIN_USER)

--- a/vue-app/src/plugins/Web3/index.ts
+++ b/vue-app/src/plugins/Web3/index.ts
@@ -91,7 +91,6 @@ export default {
         // Separate the concept of User from here. Create the User when the
         // connection is made, from the consumer.
         encryptionKey: sha256(signature),
-        isVerified: null,
         balance: null,
         contribution: null,
         walletProvider: new Web3Provider(conn.provider),

--- a/vue-app/src/store/index.ts
+++ b/vue-app/src/store/index.ts
@@ -24,12 +24,7 @@ import { getRecipientRegistryAddress } from '@/api/projects'
 import { RoundInfo, RoundStatus, getRoundInfo } from '@/api/round'
 import { storage } from '@/api/storage'
 import { Tally, getTally } from '@/api/tally'
-import {
-  User,
-  isVerifiedUser,
-  getEtherBalance,
-  getTokenBalance,
-} from '@/api/user'
+import { User, getEtherBalance, getTokenBalance } from '@/api/user'
 import {
   getRegistryInfo,
   RecipientApplicationData,
@@ -278,13 +273,6 @@ const actions = {
   },
   async [LOAD_USER_INFO]({ commit, state }) {
     if (state.currentRound && state.currentUser) {
-      let isVerified = state.currentUser.isVerified
-      if (!isVerified) {
-        isVerified = await isVerifiedUser(
-          state.currentRound.userRegistryAddress,
-          state.currentUser.walletAddress
-        )
-      }
       const etherBalance = await getEtherBalance(
         state.currentUser.walletAddress
       )
@@ -314,7 +302,6 @@ const actions = {
 
       commit(SET_CURRENT_USER, {
         ...state.currentUser,
-        isVerified,
         balance,
         etherBalance,
       })

--- a/vue-app/src/store/index.ts
+++ b/vue-app/src/store/index.ts
@@ -78,6 +78,7 @@ import {
 
 // Utils
 import { getSecondsFromNow, hasDateElapsed } from '@/utils/dates'
+import { UserRegistryType, userRegistryType } from '@/api/core'
 
 Vue.use(Vuex)
 
@@ -292,7 +293,7 @@ const actions = {
         isSponsored: true,
         isVerified: true,
       }
-      if (!isRegistered) {
+      if (!isRegistered && userRegistryType === UserRegistryType.BRIGHT_ID) {
         // Fetch brightId info
         brightId = await getBrightId(state.currentUser.walletAddress)
       }

--- a/vue-app/src/views/Profile.vue
+++ b/vue-app/src/views/Profile.vue
@@ -78,7 +78,7 @@ import CopyButton from '@/components/CopyButton.vue'
 import { LOGOUT_USER } from '@/store/action-types'
 import { User } from '@/api/user'
 
-import { userRegistryType } from '@/api/core'
+import { userRegistryType, UserRegistryType } from '@/api/core'
 
 @Component({
   components: { BalanceItem, BrightIdWidget, IconStatus, CopyButton },
@@ -101,7 +101,7 @@ export default class NavBar extends Vue {
   }
 
   get showBrightIdWidget(): boolean {
-    return userRegistryType === 'brightid'
+    return userRegistryType === UserRegistryType.BRIGHT_ID
   }
 
   renderUserAddress(digitsToShow?: number): string {

--- a/vue-app/src/views/VerifyLanding.vue
+++ b/vue-app/src/views/VerifyLanding.vue
@@ -42,12 +42,9 @@
             still get BrightID verified to prepare for next time.
           </div>
           <div class="btn-container">
-            <wallet-widget
-              v-if="walletProvider && !currentUser"
-              :isActionButton="true"
-            />
+            <wallet-widget v-if="!currentUser" :isActionButton="true" />
             <router-link
-              v-if="!walletProvider || currentUser"
+              v-if="currentUser"
               to="/verify/connect"
               class="btn-primary"
               >Get started</router-link
@@ -74,10 +71,6 @@ import WalletWidget from '@/components/WalletWidget.vue'
   components: { ProgressBar, RoundStatusBanner, WalletWidget },
 })
 export default class VerifyLanding extends Vue {
-  get walletProvider(): any {
-    return this.$store.state.currentUser?.walletProvider
-  }
-
   get currentUser(): User | null {
     return this.$store.state.currentUser
   }


### PR DESCRIPTION
This PR addresses the following: fetch BrightID data and populate the user state.

This is the first iteration. Next ones are going to be focus on UI.

TODO:
- [x] Move `isRegistered` flag out from `brightId` state and put it in the `User` again
- [x] Move `getBrightId` logic from the `WalletModal` component to the store