### PR TITLE
BrightID landing page cleanup

### DIFF
--- a/vue-app/src/store/index.ts
+++ b/vue-app/src/store/index.ts
@@ -565,6 +565,12 @@ const getters = {
       (getters.isRoundContributionPhase || getters.isRoundReallocationPhase)
     )
   },
+  isMessageLimitReached: (state: RootState): boolean => {
+    return (
+      !!state.currentRound &&
+      state.currentRound.maxMessages <= state.currentRound.messages
+    )
+  },
 }
 
 const store: StoreOptions<RootState> = {

--- a/vue-app/src/views/JoinLanding.vue
+++ b/vue-app/src/views/JoinLanding.vue
@@ -229,7 +229,7 @@ h1 {
       rgba(173, 131, 218, 0) -32.78%,
       #191623 78.66%
     );
-    @media (max-width: ($breakpoint-m)) {
+    @media (max-width: $breakpoint-m) {
       width: 100%;
       padding-bottom: 0rem;
     }
@@ -242,7 +242,7 @@ h1 {
       max-width: 88%;
       max-height: 100%;
 
-      @media (max-width: ($breakpoint-m)) {
+      @media (max-width: $breakpoint-m) {
         right: 1rem;
         width: 100%;
       }
@@ -255,13 +255,12 @@ h1 {
   z-index: 1;
   box-sizing: border-box;
   padding: $content-space;
-  width: min(100%, 512px);
   margin-left: 2rem;
   width: min(100%, 512px);
-  @media (max-width: ($breakpoint-m)) {
+  @media (max-width: $breakpoint-m) {
     width: 100%;
     margin: 0;
-    padding-bottom: 10rem;
+    padding-bottom: 35vw;
   }
 }
 

--- a/vue-app/src/views/VerifyLanding.vue
+++ b/vue-app/src/views/VerifyLanding.vue
@@ -46,7 +46,7 @@
         <router-link v-if="currentUser" to="/verify/connect" class="btn-primary"
           >I have BrightID installed</router-link
         >
-        <router-link to="/" class="btn-secondary">Go home</router-link>
+        <router-link to="/projects" class="btn-secondary">Go back</router-link>
       </div>
     </div>
   </div>

--- a/vue-app/src/views/VerifyLanding.vue
+++ b/vue-app/src/views/VerifyLanding.vue
@@ -16,7 +16,14 @@
         We use BrightID to stop bots and cheaters, and make our funding more
         democratic.
       </div>
-      <h2>What you'll need</h2>
+      <h2>
+        What you'll need
+        <tooltip
+          position="top"
+          content="If you've previously donated to a CLR round, use the same wallet to bypass some BrightID steps"
+          ><img width="16px" src="@/assets/info.svg" class="info-icon"
+        /></tooltip>
+      </h2>
       <ul>
         <li>
           BrightID – available on
@@ -61,9 +68,15 @@ import ProgressBar from '@/components/ProgressBar.vue'
 import RoundStatusBanner from '@/components/RoundStatusBanner.vue'
 import { commify, formatUnits } from '@ethersproject/units'
 import WalletWidget from '@/components/WalletWidget.vue'
+import Tooltip from '@/components/Tooltip.vue'
 
 @Component({
-  components: { ProgressBar, RoundStatusBanner, WalletWidget },
+  components: {
+    ProgressBar,
+    RoundStatusBanner,
+    WalletWidget,
+    Tooltip,
+  },
 })
 export default class VerifyLanding extends Vue {
   get currentUser(): User | null {
@@ -223,5 +236,9 @@ ul {
   margin: 1rem 0 0;
   color: $error-color;
   font-size: 14px;
+}
+
+.info-icon {
+  margin-left: 0.5rem;
 }
 </style>

--- a/vue-app/src/views/VerifyLanding.vue
+++ b/vue-app/src/views/VerifyLanding.vue
@@ -80,7 +80,7 @@ export default class VerifyLanding extends Vue {
 
   get isRoundFullOrOver(): boolean {
     return (
-      this.$store.getters.isRecipientRegistryFull ||
+      this.$store.getters.isMessageLimitReached ||
       this.$store.getters.hasContributionPhaseEnded
     )
   }

--- a/vue-app/src/views/VerifyLanding.vue
+++ b/vue-app/src/views/VerifyLanding.vue
@@ -33,7 +33,7 @@
             >Android</a
           >
         </li>
-        <li>An Ethereum wallet</li>
+        <li>An Ethereum wallet, with enough gas for two transactions</li>
         <li>Access to Zoom or Google Meet</li>
       </ul>
       <router-link to="/sybil-resistance/">Why is this important?</router-link>

--- a/vue-app/src/views/VerifyLanding.vue
+++ b/vue-app/src/views/VerifyLanding.vue
@@ -92,7 +92,11 @@ export default class VerifyLanding extends Vue {
   }
 
   get isRoundFullOrOver(): boolean {
+    const hasHitMaxContributors =
+      this.$store.state.currentRound.maxContributors <=
+      this.$store.state.currentRound.contributors
     return (
+      !hasHitMaxContributors ||
       this.$store.getters.isMessageLimitReached ||
       this.$store.getters.hasContributionPhaseEnded
     )

--- a/vue-app/src/views/VerifyLanding.vue
+++ b/vue-app/src/views/VerifyLanding.vue
@@ -96,9 +96,9 @@ export default class VerifyLanding extends Vue {
       this.$store.state.currentRound.maxContributors <=
       this.$store.state.currentRound.contributors
     return (
-      !hasHitMaxContributors ||
+      this.$store.getters.hasContributionPhaseEnded ||
       this.$store.getters.isMessageLimitReached ||
-      this.$store.getters.hasContributionPhaseEnded
+      hasHitMaxContributors
     )
   }
 

--- a/vue-app/src/views/VerifyLanding.vue
+++ b/vue-app/src/views/VerifyLanding.vue
@@ -6,52 +6,47 @@
       <img src="@/assets/moon.png" class="moon" />
       <div class="hero">
         <img src="@/assets/newrings.png" />
-        <div class="content">
-          <div class="flex-title">
-            <h1>Prove you’re only using 1 account</h1>
-          </div>
-          <div class="subtitle">
-            We use BrightID to stop bots and cheaters, and make our funding more
-            democratic.
-          </div>
-          <h2>What you'll need</h2>
-          <ul>
-            <li>
-              BrightID – available on
-              <a
-                href="https://apps.apple.com/us/app/brightid/id1428946820"
-                target="_blank"
-              >
-                iOS</a
-              >
-              or
-              <a
-                href="https://play.google.com/store/apps/details?id=org.brightid"
-                target="_blank"
-                >Android</a
-              >
-            </li>
-            <li>An Ethereum wallet</li>
-            <li>Access to Zoom or Google Meet</li>
-          </ul>
-          <router-link to="/sybil-resistance/"
-            >Why is this important?</router-link
+      </div>
+    </div>
+    <div class="content">
+      <div class="flex-title">
+        <h1>Prove you’re only using one account</h1>
+      </div>
+      <div class="subtitle">
+        We use BrightID to stop bots and cheaters, and make our funding more
+        democratic.
+      </div>
+      <h2>What you'll need</h2>
+      <ul>
+        <li>
+          BrightID – available on
+          <a
+            href="https://apps.apple.com/us/app/brightid/id1428946820"
+            target="_blank"
           >
-          <div v-if="isRoundFullOrOver" class="warning-message">
-            The current round is no longer accepting new contributions. You can
-            still get BrightID verified to prepare for next time.
-          </div>
-          <div class="btn-container">
-            <wallet-widget v-if="!currentUser" :isActionButton="true" />
-            <router-link
-              v-if="currentUser"
-              to="/verify/connect"
-              class="btn-primary"
-              >Get started</router-link
-            >
-            <router-link to="/" class="btn-secondary">Go home</router-link>
-          </div>
-        </div>
+            iOS</a
+          >
+          or
+          <a
+            href="https://play.google.com/store/apps/details?id=org.brightid"
+            target="_blank"
+            >Android</a
+          >
+        </li>
+        <li>An Ethereum wallet</li>
+        <li>Access to Zoom or Google Meet</li>
+      </ul>
+      <router-link to="/sybil-resistance/">Why is this important?</router-link>
+      <div v-if="isRoundFullOrOver" class="warning-message">
+        The current round is no longer accepting new contributions. You can
+        still get BrightID verified to prepare for next time.
+      </div>
+      <div class="btn-container">
+        <wallet-widget v-if="!currentUser" :isActionButton="true" />
+        <router-link v-if="currentUser" to="/verify/connect" class="btn-primary"
+          >I have BrightID installed</router-link
+        >
+        <router-link to="/" class="btn-secondary">Go home</router-link>
       </div>
     </div>
   </div>
@@ -110,7 +105,6 @@ h1 {
   font-weight: bold;
   font-size: 40px;
   line-height: 120%;
-  margin: 0;
 }
 
 h2 {
@@ -136,7 +130,11 @@ ul {
 
 .gradient {
   background: $clr-pink-dark-gradient;
-  position: relative;
+  position: fixed;
+  top: 0;
+  right: 0;
+  height: 100%;
+  width: 100%;
 
   .moon {
     position: absolute;
@@ -145,17 +143,20 @@ ul {
     mix-blend-mode: exclusion;
   }
   .hero {
-    bottom: 0;
     display: flex;
+    position: fixed;
+    top: 0;
+    right: 0;
+    height: 100%;
+    width: 100%;
     background: linear-gradient(
       286.78deg,
       rgba(173, 131, 218, 0) -32.78%,
       #191623 78.66%
     );
-    height: calc(100vh - 113px);
     @media (max-width: $breakpoint-m) {
       padding: 2rem 0rem;
-      padding-bottom: 16rem;
+      padding-bottom: 0rem;
     }
 
     img {
@@ -169,39 +170,37 @@ ul {
         width: 100%;
       }
     }
+  }
+}
+.content {
+  position: relative;
+  z-index: 1;
+  padding: $content-space;
+  width: min(100%, 512px);
+  margin: 2rem;
+  box-sizing: border-box;
+  @media (max-width: $breakpoint-m) {
+    width: 100%;
+    margin: 0;
+    padding-bottom: 35vw;
+  }
 
-    .content {
+  .flex-title {
+    display: flex;
+    gap: 0.5rem;
+    align-items: center;
+    flex-wrap: wrap;
+
+    img {
+      width: 1rem;
+      height: 1rem;
       position: relative;
-      z-index: 1;
-      padding: $content-space;
-      width: min(100%, 512px);
-      margin-left: 2rem;
-      margin-top: 3rem;
-      @media (max-width: $breakpoint-m) {
-        width: 100%;
-        margin: 0;
-      }
-
-      .flex-title {
-        display: flex;
-        gap: 0.5rem;
-        align-items: center;
-        margin-bottom: 3rem;
-        margin-top: 1.5rem;
-        flex-wrap: wrap;
-
-        img {
-          width: 1rem;
-          height: 1rem;
-          position: relative;
-          right: 0;
-        }
-      }
-
-      .btn-container {
-        margin-top: 2rem;
-      }
+      right: 0;
     }
+  }
+
+  .btn-container {
+    margin-top: 2rem;
   }
 }
 
@@ -224,8 +223,5 @@ ul {
   margin: 1rem 0 0;
   color: $error-color;
   font-size: 14px;
-  // &:before {
-  //   content: "⚠️ "
-  // }
 }
 </style>


### PR DESCRIPTION
(branch of `brightid-integration-2`)

Notion card: [BrightID landing page](https://www.notion.so/efdn/BrightID-landing-page-df333b150a3b4bae928c9da779b063b3)

### Changes
- Layout adjustments for background/hero
- Adjusts logic for `isRoundFullOrOver` with new `getter` that checks is message cap has been hit, instead of if recipients registry is full.
- Adds some copy for UX
- Updates button copy to match design

### Questions that came out of this (See Notion doc for screenshots)
- Connect button is forced to `fit-content`... should we refactor this with an option to keep it full width? 
- "...to prepare for next time." Should we consider changing this copy if we're going to keep focus on a single round trial?