### PR TITLE
Placeholder text correction

### DIFF
--- a/vue-app/src/views/Join.vue
+++ b/vue-app/src/views/Join.vue
@@ -424,7 +424,7 @@
                   <input
                     id="links-website"
                     type="link"
-                    placeholder="example: https://website.com/ethereum/clrfund"
+                    placeholder="example: https://ethereum.foundation"
                     class="input"
                     v-model="$v.form.links.website.$model"
                     :class="{
@@ -446,7 +446,7 @@
                   <input
                     id="links-twitter"
                     type="link"
-                    placeholder="example: https://github.com/ethereum/clrfund"
+                    placeholder="example: https://twitter.com/ethereum"
                     class="input"
                     v-model="$v.form.links.twitter.$model"
                     :class="{
@@ -468,7 +468,7 @@
                   <input
                     id="links-discord"
                     type="link"
-                    placeholder="example: https://github.com/ethereum/clrfund"
+                    placeholder="example: https://discord.gg/5Prub9zbGz"
                     class="input"
                     v-model="$v.form.links.discord.$model"
                     :class="{

--- a/vue-app/src/views/Join.vue
+++ b/vue-app/src/views/Join.vue
@@ -242,7 +242,7 @@
                   </p>
                   <input
                     id="fund-address"
-                    placeholder="example: clr.eth, clr.crypto, 0x123..."
+                    placeholder="example: 0x123..."
                     v-model="$v.form.fund.address.$model"
                     :class="{
                       input: true,


### PR DESCRIPTION
User feedback pointed out the placeholder text for the link fields in the `Join` form do not all match the field they belong to. This corrects the issue, and also removes the placeholder text suggesting ENS or Unstoppable Domain addresses while that functionality is not yet built in. 