### PR TITLE
Adds component getters for block explorer urls

### DIFF
--- a/vue-app/.env.example
+++ b/vue-app/.env.example
@@ -1,7 +1,7 @@
 VUE_APP_ETHEREUM_API_URL=http://localhost:18545
 VUE_APP_ETHEREUM_API_CHAINID=31337
 VUE_APP_INFURA_ID=
-VUE_APP_BLOCK_EXPLORER=https://etherscan.io/tx/
+VUE_APP_BLOCK_EXPLORER=https://etherscan.io
 VUE_APP_IPFS_GATEWAY_URL=https://ipfs.io
 
 # Comma-separated list of URLs

--- a/vue-app/src/api/core.ts
+++ b/vue-app/src/api/core.ts
@@ -5,7 +5,8 @@ import { FundingRoundFactory } from './abi'
 export const provider = new ethers.providers.StaticJsonRpcProvider(
   process.env.VUE_APP_ETHEREUM_API_URL
 )
-export const blockExplorer = process.env.VUE_APP_BLOCK_EXPLORER
+export const blockExplorer =
+  process.env.VUE_APP_BLOCK_EXPLORER || 'https://etherscan.io'
 export const ipfsGatewayUrl = process.env.VUE_APP_IPFS_GATEWAY_URL
 export const gunPeers: string[] = process.env.VUE_APP_GUN_PEERS
   ? process.env.VUE_APP_GUN_PEERS.split(',')

--- a/vue-app/src/components/ProjectProfile.vue
+++ b/vue-app/src/components/ProjectProfile.vue
@@ -109,7 +109,7 @@
           />
           <a
             class="explorerLink"
-            :href="`${blockExplorer}/address/${project.address}`"
+            :href="blockExplorerUrl"
             target="_blank"
             title="View on Etherscan"
           >
@@ -264,8 +264,8 @@ export default class ProjectProfile extends Vue {
     )
   }
 
-  private get blockExplorer(): string {
-    return blockExplorer
+  get blockExplorerUrl(): string {
+    return `${blockExplorer}/address/${this.project.address}`
   }
 }
 </script>

--- a/vue-app/src/components/ProjectProfile.vue
+++ b/vue-app/src/components/ProjectProfile.vue
@@ -109,7 +109,7 @@
           />
           <a
             class="explorerLink"
-            :href="`https://etherscan.io/address/${project.address}`"
+            :href="`${blockExplorer}/address/${project.address}`"
             target="_blank"
             title="View on Etherscan"
           >
@@ -145,6 +145,7 @@ import Markdown from '@/components/Markdown.vue'
 import CopyButton from '@/components/CopyButton.vue'
 import { DEFAULT_CONTRIBUTION_AMOUNT, CartItem } from '@/api/contributions'
 import { RoundStatus } from '@/api/round'
+import { blockExplorer } from '@/api/core'
 import { SAVE_CART } from '@/store/action-types'
 import { ADD_CART_ITEM } from '@/store/mutation-types'
 import ClaimModal from '@/components/ClaimModal.vue'
@@ -261,6 +262,10 @@ export default class ProjectProfile extends Vue {
         },
       }
     )
+  }
+
+  private get blockExplorer(): string {
+    return blockExplorer
   }
 }
 </script>

--- a/vue-app/src/components/RoundInformation.vue
+++ b/vue-app/src/components/RoundInformation.vue
@@ -11,10 +11,7 @@
             <tooltip
               position="top"
               :content="currentRound.fundingRoundAddress"
-              :link="
-                'https://etherscan.io/address/' +
-                currentRound.fundingRoundAddress
-              "
+              :link="blockExplorerUrl"
               linkText="View on Etherscan"
               ><div class="verified"><img src="@/assets/verified.svg" /></div
             ></tooltip>
@@ -299,6 +296,7 @@ import {
   getRecipientRegistryAddress,
   getProjects,
 } from '@/api/projects'
+import { blockExplorer } from '@/api/core'
 
 import { getTimeLeft } from '@/utils/dates'
 import { formatAmount } from '@/utils/amounts'
@@ -453,6 +451,13 @@ export default class RoundInformation extends Vue {
         },
       }
     )
+  }
+
+  get blockExplorerUrl(): string {
+    if (!this.currentRound) {
+      return ''
+    }
+    return `${blockExplorer}/address/${this.currentRound.fundingRoundAddress}`
   }
 }
 </script>

--- a/vue-app/src/components/Transaction.vue
+++ b/vue-app/src/components/Transaction.vue
@@ -63,7 +63,7 @@ export default class Transaction extends Vue {
   error!: string
 
   getBlockExplorerUrl(transactionHash: string): string {
-    return `${blockExplorer}${transactionHash}`
+    return `${blockExplorer}/tx/${transactionHash}`
   }
 }
 </script>

--- a/vue-app/src/components/TransactionReceipt.vue
+++ b/vue-app/src/components/TransactionReceipt.vue
@@ -9,7 +9,7 @@
     <div class="actions">
       <a
         class="explorerLink"
-        :href="'https://etherscan.io/tx/' + hash"
+        :href="blockExplorerUrl"
         target="_blank"
         title="View on Etherscan"
         ><img class="icon" src="@/assets/etherscan.svg"
@@ -75,7 +75,7 @@ export default class TransactionReceipt extends Vue {
   }
 
   get blockExplorerUrl(): string {
-    return `${blockExplorer}${this.hash}`
+    return `${blockExplorer}/tx/${this.hash}`
   }
 }
 </script>

--- a/vue-app/src/views/Join.vue
+++ b/vue-app/src/views/Join.vue
@@ -566,12 +566,7 @@
                   <h4 class="read-only-title">Ethereum address</h4>
                   <div class="data break-all">
                     {{ form.fund.address }}
-                    <a
-                      :href="
-                        'https://etherscan.io/address/' + form.fund.address
-                      "
-                      target="_blank"
-                      class="no-break"
+                    <a :href="blockExplorerUrl" target="_blank" class="no-break"
                       >View on Etherscan</a
                     >
                   </div>
@@ -750,6 +745,7 @@ import {
   formToProjectInterface,
 } from '@/api/recipient-registry-optimistic'
 import { Project } from '@/api/projects'
+import { blockExplorer } from '@/api/core'
 
 @Component({
   components: {
@@ -1004,6 +1000,10 @@ export default class JoinView extends mixins(validationMixin) {
 
   get furthestStep() {
     return this.form.furthestStep
+  }
+
+  get blockExplorerUrl(): string {
+    return `${blockExplorer}/address/${this.form.fund.address}`
   }
 }
 </script>

--- a/vue-app/src/views/ProjectAdded.vue
+++ b/vue-app/src/views/ProjectAdded.vue
@@ -71,7 +71,7 @@ export default class ProjectAdded extends Vue {
   }
 
   get blockExplorerUrl(): string {
-    return `${blockExplorer}${this.txHash}`
+    return `${blockExplorer}/tx/${this.txHash}`
   }
 
   formatDuration(seconds: number): string {

--- a/vue-app/src/views/Verified.vue
+++ b/vue-app/src/views/Verified.vue
@@ -54,7 +54,7 @@ export default class Verified extends Vue {
   txHash = '0xfakehashf7261d65be24e7f5cabefba4a659e1e2e13685cc03ad87233ee2713d'
 
   get blockExplorerUrl(): string {
-    return `${blockExplorer}${this.txHash}`
+    return `${blockExplorer}/tx/${this.txHash}`
   }
 
   formatDuration(value: number): string {


### PR DESCRIPTION
- Removes hard-coded block explorer links, replaces with `.env` variable
- Removed `/tx/` from the end of the block explorer template URL in `.env.example` so this base link can be used for both tx and address lookups depending on the circumstance.