### PR TITLE
MatchingFundsModal - input validation working bad

### DIFF
--- a/vue-app/src/components/MatchingFundsModal.vue
+++ b/vue-app/src/components/MatchingFundsModal.vue
@@ -32,7 +32,10 @@
             />
           </div>
         </form>
-        <div v-if="amount > balance" class="balance-check-warning">
+        <div
+          v-if="parseFloat(amount) > parseFloat(balance)"
+          class="balance-check-warning"
+        >
           ⚠️ You only have {{ balance }} {{ tokenSymbol }}
         </div>
         <div class="btn-row">


### PR DESCRIPTION
Notion: https://efdn.notion.site/Matching-funds-input-validation-677d7881cf7446dea23b7e53d8120612
Fixes: https://github.com/ethereum/clrfund/issues/213

What changed:
- added parseFloat for typecasting when comparing amount and balance