### PR TITLE
Fixes box shadow styling on modals

### DIFF
--- a/vue-app/src/App.vue
+++ b/vue-app/src/App.vue
@@ -467,12 +467,15 @@ summary:focus {
 
 .vm--modal {
   background-color: transparent !important;
+  box-shadow: none !important;
+  overflow: visible !important;
 }
 
 .modal-body {
   background-color: $bg-light-color;
   padding: $modal-space;
   text-align: center;
+  box-shadow: 0 20px 60px -2px rgba(27, 33, 58, 0.4);
 
   .loader {
     margin: $modal-space auto;

--- a/vue-app/src/App.vue
+++ b/vue-app/src/App.vue
@@ -465,6 +465,10 @@ summary:focus {
   margin-left: 0.5rem;
 }
 
+.vm--overlay {
+  background-color: rgba(black, 0.5) !important;
+}
+
 .vm--modal {
   background-color: transparent !important;
   box-shadow: none !important;

--- a/vue-app/src/App.vue
+++ b/vue-app/src/App.vue
@@ -475,7 +475,7 @@ summary:focus {
   background-color: $bg-light-color;
   padding: $modal-space;
   text-align: center;
-  box-shadow: 0 20px 60px -2px rgba(27, 33, 58, 0.4);
+  box-shadow: $box-shadow;
 
   .loader {
     margin: $modal-space auto;


### PR DESCRIPTION
Removes `box-shadow` from `.vm--modal` class, which was the full height modal container.

Replaces this by adding `box-shadow: $box-shadow;` to the `.modal-body` class instead:

![image](https://user-images.githubusercontent.com/54227730/129979726-5cc45472-787b-4ce2-8f51-f71cf6be4810.png)
