### PR TITLE
Adds check for `isMessageLimitReached` to `isRoundFull` on JoinLanding [Fixes #228]

### DIFF
--- a/vue-app/src/views/JoinLanding.vue
+++ b/vue-app/src/views/JoinLanding.vue
@@ -168,7 +168,9 @@ export default class JoinLanding extends Vue {
     if (this.spacesRemaining === null) {
       return false
     }
-    return this.spacesRemaining === 0
+    return (
+      this.spacesRemaining === 0 || this.$store.getters.isMessageLimitReached
+    )
   }
 
   get isRoundFillingUp(): boolean {


### PR DESCRIPTION
Adds `isMessageLimitReached` getter (from #232) when checking if the round is full on the JoinLanding page. 

This does not change the `isRoundFillingUp` check, but we could consider picking a message threshold and adding this with a unique alert that says voting is almost filled up.

Went with this simple approach for now to just cover the extreme edge case of us going beyond the planned 2^32 messages, and in that case it just triggers the registry as full. 