### PR TITLE
fix: when round is done, now display closed and remove ability to add…

### DIFF
--- a/vue-app/src/components/RoundInformation.vue
+++ b/vue-app/src/components/RoundInformation.vue
@@ -23,9 +23,19 @@
             </v-popover>
           </div>
           <!-- TODO add logic to status -->
-          <div class="status">
+          <div
+            class="status"
+            v-if="
+              !$store.getters.isRoundFinalized &&
+              !$store.getters.isRoundTallying
+            "
+          >
             <div class="circle open-pulse" />
             Open
+          </div>
+          <div v-else class="status">
+            <div class="circle closed" />
+            Closed
           </div>
         </div>
         <div class="round-info-item" v-if="$store.getters.isRoundJoinOnlyPhase">
@@ -202,6 +212,10 @@
                 src="@/assets/info.svg"
               />
               <div
+                v-if="
+                  !$store.getters.isRoundFinalized &&
+                  !$store.getters.isRoundTallying
+                "
                 v-tooltip="'Add matching funds'"
                 class="add-link"
                 @click="addMatchingFunds"
@@ -482,6 +496,12 @@ export default class RoundInformation extends Vue {
   height: 8px;
   border-radius: 50%;
   margin-right: 0.5rem;
+}
+
+.closed {
+  width: 12px;
+  height: 12px;
+  background: $bg-light-color;
 }
 
 .open-pulse {

--- a/vue-app/src/components/RoundInformation.vue
+++ b/vue-app/src/components/RoundInformation.vue
@@ -22,7 +22,6 @@
               </template>
             </v-popover>
           </div>
-          <!-- TODO add logic to status -->
           <div
             class="status"
             v-if="


### PR DESCRIPTION
Notable issues within this:
- [x]  "Open" indicator should be "Closed".
- [x]  "⊕ Add funds" and "•••" indicator both open modal to "Contribute to next round"... wanted to double check this is what we want when the Eth2 round finalizes
- [x]  Endless spinner on bottom left
- [x]  "Contributions are ready to claim" yet there is no button to claim for eligible recipient

Fixes: https://github.com/ethereum/clrfund/issues/205