### PR TITLE
Consolidates `disabled` styling into boolean attribute [Fixes #278]

### DIFF
--- a/vue-app/src/components/Cart.vue
+++ b/vue-app/src/components/Cart.vue
@@ -218,14 +218,7 @@
         </button>
         <button
           v-if="!isCartEmpty"
-          :class="{
-            'btn-action': !errorMessage,
-            'btn-action disabled':
-              errorMessage ||
-              ($store.getters.hasUserContributed &&
-                $store.getters.hasUserVoted &&
-                !isDirty),
-          }"
+          class="btn-action"
           @click="submitCart"
           :disabled="
             errorMessage ||
@@ -1082,16 +1075,6 @@ h2 {
 
 .moon-emoji {
   font-size: 4rem;
-}
-
-.disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
-  &:hover {
-    transform: none;
-    cursor: not-allowed;
-    opacity: 0.5;
-  }
 }
 
 .reallocation-row {

--- a/vue-app/src/components/FormNavigation.vue
+++ b/vue-app/src/components/FormNavigation.vue
@@ -6,9 +6,7 @@
         v-if="currentStep > 0"
         @click="handleStepNav(currentStep - 1)"
         class="btn-secondary"
-        :class="{
-          disabled: isNavDisabled,
-        }"
+        :disabled="isNavDisabled"
       >
         Previous
       </button>
@@ -26,9 +24,7 @@
         v-if="currentStep > 0"
         @click="handleStepNav(currentStep - 1)"
         class="btn-secondary"
-        :class="{
-          disabled: isNavDisabled,
-        }"
+        :disabled="isNavDisabled"
       >
         Previous
       </button>
@@ -91,17 +87,6 @@ export default class FormNavigation extends Vue {
   align-items: center;
   @media (max-width: $breakpoint-m) {
     bottom: 0;
-  }
-}
-
-.disabled {
-  cursor: not-allowed;
-  opacity: 0.5;
-
-  &:hover {
-    opacity: 0.5;
-    transform: scale(1);
-    cursor: not-allowed;
   }
 }
 </style>

--- a/vue-app/src/components/IpfsImageUpload.vue
+++ b/vue-app/src/components/IpfsImageUpload.vue
@@ -20,7 +20,6 @@
         type="submit"
         label="Upload"
         class="btn-primary"
-        :class="{ disabled: loading || error || !loadedImageData }"
         :disabled="loading || error || !loadedImageData"
       >
         {{ loading ? 'Uploading...' : 'Upload' }}
@@ -189,17 +188,6 @@ export default class IpfsImageUpload extends Vue {
     object-fit: cover;
     width: 100%;
     height: 100%;
-  }
-}
-
-.disabled {
-  cursor: not-allowed;
-  opacity: 0.5;
-
-  &:hover {
-    opacity: 0.5;
-    transform: scale(1);
-    cursor: not-allowed;
   }
 }
 

--- a/vue-app/src/components/ProjectProfile.vue
+++ b/vue-app/src/components/ProjectProfile.vue
@@ -472,6 +472,7 @@ export default class ProjectProfile extends Vue {
     border: none;
     cursor: pointer;
     box-shadow: 0px 4px 4px 0px 0, 0, 0, 0.25;
+    @include disabledAttribute;
   }
 
   .donate-btn-full {

--- a/vue-app/src/components/RecipientSubmissionWidget.vue
+++ b/vue-app/src/components/RecipientSubmissionWidget.vue
@@ -95,12 +95,8 @@
         <div class="cta">
           <button
             @click="handleSubmit"
-            :class="
-              isWaiting || isPending || hasLowFunds
-                ? 'btn-action-disabled'
-                : 'btn-action'
-            "
-            :disabled="!canSubmit"
+            class="btn-action"
+            :disabled="!canSubmit || isWaiting || isPending || hasLowFunds"
           >
             <div v-if="isWaiting || isPending">
               <loader class="button-loader" />

--- a/vue-app/src/styles/_theme.scss
+++ b/vue-app/src/styles/_theme.scss
@@ -1,5 +1,14 @@
 @import './vars';
 
+@mixin disabledAttribute() {
+  &[disabled],
+  &[disabled]:hover {
+    opacity: 0.5;
+    cursor: not-allowed;
+    transform: none;
+  }
+}
+
 @mixin button($color, $background, $border) {
   display: block;
   box-sizing: border-box;
@@ -19,6 +28,7 @@
     transform: scale(1.02);
     cursor: pointer;
   }
+  @include disabledAttribute;
 }
 
 .btn-primary {

--- a/vue-app/src/views/Join.vue
+++ b/vue-app/src/views/Join.vue
@@ -1441,16 +1441,7 @@ export default class JoinView extends mixins(validationMixin) {
     border-radius: 4px;
   }
 }
-.disabled {
-  cursor: not-allowed;
-  opacity: 0.5;
 
-  &:hover {
-    opacity: 0.5;
-    transform: scale(1);
-    cursor: not-allowed;
-  }
-}
 .pt-1 {
   padding-top: 1rem;
 }

--- a/vue-app/src/views/Verify.vue
+++ b/vue-app/src/views/Verify.vue
@@ -78,7 +78,7 @@
                 v-if="!isManuallyVerified"
                 @click="handleIsVerifiedClick"
                 class="btn-primary"
-                :class="{ disabled: loadingManualVerify }"
+                :disabled="loadingManualVerify"
               >
                 Check if you are verified
               </button>
@@ -1093,16 +1093,7 @@ export default class VerifyView extends Vue {
     border-radius: 4px;
   }
 }
-.disabled {
-  cursor: not-allowed;
-  opacity: 0.5;
 
-  &:hover {
-    opacity: 0.5;
-    transform: scale(1);
-    cursor: not-allowed;
-  }
-}
 .pt-1 {
   padding-top: 1rem;
 }


### PR DESCRIPTION
### Description
Moved styling to `_theme.scss` as a mixin that is used with all of our themed buttons, and can also be applied to other elements or custom buttons by using `@include disabledAttribute;` in that elements CSS. No need to use so many conditional classes this way.

- [x] Awaiting merge of #262 to finish rollout

### Related issues
[Fixes #278]