### PR TITLE
Fix text readability on transaction success page

### DIFF
--- a/vue-app/src/views/TransactionSuccess.vue
+++ b/vue-app/src/views/TransactionSuccess.vue
@@ -112,6 +112,7 @@ export default class TransactionSuccess extends Vue {
   width: 100%;
   display: flex;
   justify-content: center;
+  opacity:0.8;
 }
 
 .image-wrapper .docking {


### PR DESCRIPTION
Fixes #276 
I reduced the opacity of the image-wrapper which makes the text readable. 


![image](https://user-images.githubusercontent.com/35653876/130258070-9eff502c-b13a-4d72-8b07-d07bef242ba1.png)
