### PR TITLE
TransactionSuccess layout fixes [Fixes #286]

### DIFF
--- a/vue-app/src/components/TransactionReceipt.vue
+++ b/vue-app/src/components/TransactionReceipt.vue
@@ -1,16 +1,24 @@
 <template>
   <div class="etherscan-btn tx-receipt">
     <div class="status-label-address">
-      <loader v-if="isPending" class="pending" />
-      <!-- TODO: add tooltip for pending -->
-      <img class="success" v-if="!isPending" src="@/assets/checkmark.svg" />
+      <loader
+        v-if="isPending"
+        v-tooltip="'Awaiting transaction confirmation'"
+        class="pending"
+      />
+      <img
+        class="success"
+        v-tooltip="'Transaction confirmed'"
+        v-if="!isPending"
+        src="@/assets/checkmark.svg"
+      />
       <p class="hash">{{ renderCopiedOrHash }}</p>
     </div>
     <div class="actions">
       <links
         class="explorerLink"
         :to="blockExplorerUrl"
-        title="View on Etherscan"
+        v-tooltip="'View on Etherscan'"
         :hideArrow="true"
         ><img class="icon" src="@/assets/etherscan.svg"
       /></links>
@@ -53,7 +61,7 @@ export default class TransactionReceipt extends Vue {
   }
 
   get renderCopiedOrHash(): string {
-    return this.isCopied ? 'Copied!' : this.renderHash(8)
+    return this.isCopied ? 'Copied!' : this.renderHash(16)
   }
 
   async checkTxStatus(): Promise<void> {

--- a/vue-app/src/components/TransactionReceipt.vue
+++ b/vue-app/src/components/TransactionReceipt.vue
@@ -86,7 +86,6 @@ export default class TransactionReceipt extends Vue {
 @import '../styles/theme';
 
 .tx-receipt {
-  min-width: 200px;
   display: flex;
   justify-content: space-between;
 }

--- a/vue-app/src/views/TransactionSuccess.vue
+++ b/vue-app/src/views/TransactionSuccess.vue
@@ -164,7 +164,6 @@ export default class TransactionSuccess extends Vue {
   line-height: 120%;
   margin-right: 0.5rem;
   color: $text-color;
-  width: 230px;
 }
 
 .contributed-content {


### PR DESCRIPTION
### Description
- Removes width restriction to TransactionSuccess page header copy
- Removes width constraint on class for copy button
- Expands number tx hash characters shown
- Also adds missing tooltip text to icons on this page

### Screenshots
![image](https://user-images.githubusercontent.com/54227730/130383591-20849688-a676-4e0a-8bf6-4576598458b4.png)

(Note: Opacity/contract issues on this page being addressed in #285)