### PR TITLE
Refactored inline styling to classes [Fixes #261]

### DIFF
--- a/vue-app/src/components/AddToCartButton.vue
+++ b/vue-app/src/components/AddToCartButton.vue
@@ -2,7 +2,7 @@
   <div>
     <form action="#" v-if="!inCart && canContribute()">
       <div class="input-button">
-        <img style="margin-left: 0.5rem" height="24px" src="@/assets/dai.svg" />
+        <img class="token-icon" height="24px" src="@/assets/dai.svg" />
         <input
           class="input"
           name="amount"

--- a/vue-app/src/components/Cart.vue
+++ b/vue-app/src/components/Cart.vue
@@ -1,5 +1,5 @@
 <template>
-  <div style="height: 100%">
+  <div class="h100">
     <div v-if="!currentUser" class="empty-cart">
       <div class="moon-emoji">🌚</div>
       <h3>Connect to see your cart</h3>
@@ -1064,6 +1064,10 @@ h2 {
     width: 100%;
     margin-bottom: 1rem;
   }
+}
+
+.h100 {
+  height: 100%;
 }
 
 .p1 {

--- a/vue-app/src/components/CartItems.vue
+++ b/vue-app/src/components/CartItems.vue
@@ -41,11 +41,7 @@
       </div>
       <form v-if="isEditMode" class="contribution-form">
         <div class="input-button">
-          <img
-            style="margin-left: 0.5rem"
-            height="24px"
-            src="@/assets/dai.svg"
-          />
+          <img class="token-icon" height="24px" src="@/assets/dai.svg" />
           <input
             :value="item.amount"
             @input="updateAmount(item, $event.target.value)"

--- a/vue-app/src/components/MatchingFundsModal.vue
+++ b/vue-app/src/components/MatchingFundsModal.vue
@@ -7,11 +7,7 @@
       </h3>
       <form class="contribution-form">
         <div class="input-button">
-          <img
-            style="margin-left: 0.5rem"
-            height="24px"
-            src="@/assets/dai.svg"
-          />
+          <img class="token-icon" height="24px" src="@/assets/dai.svg" />
           <input
             v-model="amount"
             class="input"
@@ -53,11 +49,9 @@
       ></transaction>
     </div>
     <div v-if="step === 3">
-      <div style="font-size: 64px">💦</div>
+      <div class="big-emoji">💦</div>
       <h3>You just topped up the pool by {{ amount }} {{ tokenSymbol }}!</h3>
-      <div style="margin-bottom: 2rem">
-        Thanks for helping out all our projects.
-      </div>
+      <div class="mb2">Thanks for helping out all our projects.</div>
       <button class="btn-primary" @click="$emit('close')">Done</button>
     </div>
   </div>
@@ -174,10 +168,6 @@ export default class MatchingFundsModal extends Vue {
   width: 100%;
   display: flex;
   justify-content: space-between;
-
-  .btn {
-    margin: 0 $modal-space;
-  }
 }
 
 .close-btn {

--- a/vue-app/src/components/ProjectListItem.vue
+++ b/vue-app/src/components/ProjectListItem.vue
@@ -8,18 +8,8 @@
         </div>
       </links>
       <div class="project-info">
-        <div
-          style="
-            display: flex;
-            align-items: flex-start;
-            justify-content: space-between;
-            margin-bottom: 1rem;
-          "
-        >
-          <links
-            class="project-name"
-            :to="{ name: 'project', params: { id: project.id } }"
-          >
+        <div class="project-name">
+          <links :to="{ name: 'project', params: { id: project.id } }">
             {{ project.name }}
           </links>
         </div>
@@ -176,7 +166,6 @@ export default class ProjectListItem extends Vue {
 }
 
 .project-image {
-  /* margin: 2rem 3rem; */
   margin-bottom: 1rem;
   border-radius: 8px 8px 0 0;
   height: 8rem;
@@ -188,7 +177,6 @@ export default class ProjectListItem extends Vue {
   position: relative;
 
   img {
-    /* width: 100%; */
     border-radius: 8px;
     flex-shrink: 0;
     min-width: 100%;
@@ -212,11 +200,14 @@ export default class ProjectListItem extends Vue {
 }
 
 .project-name {
-  color: #f7f7f7;
-  font-size: 20px;
+  display: flex;
+  align-items: flex-start;
   font-weight: 700;
-  font-family: Inter;
-  margin-bottom: 0.5rem;
+  margin-bottom: 1.5rem;
+  font-size: 20px;
+  * {
+    color: #f7f7f7;
+  }
 }
 
 .project-description {
@@ -224,8 +215,6 @@ export default class ProjectListItem extends Vue {
   -webkit-line-clamp: 3;
   -webkit-box-orient: vertical;
   font-size: 16px;
-  /*   height: 60px;
-  max-height: 60px; */
   overflow: hidden;
   margin-bottom: 1rem;
   color: #f7f7f7;

--- a/vue-app/src/components/ProjectProfile.vue
+++ b/vue-app/src/components/ProjectProfile.vue
@@ -2,7 +2,7 @@
   <div v-if="project" class="project-page">
     <info
       v-if="previewMode"
-      style="margin-bottom: 1.5rem"
+      class="info"
       message="This is what your contributors will see when they visit your project page."
     />
     <img
@@ -31,11 +31,7 @@
       </div>
       <div class="mobile mb2">
         <div class="input-button" v-if="hasContributeBtn() && !inCart">
-          <img
-            style="margin-left: 0.5rem"
-            height="24px"
-            src="@/assets/dai.svg"
-          />
+          <img class="token-icon" height="24px" src="@/assets/dai.svg" />
           <input
             v-model="contributionAmount"
             class="input"
@@ -282,6 +278,10 @@ export default class ProjectProfile extends Vue {
     margin-bottom: 3rem;
   }
 
+  .info {
+    margin-bottom: 1.5rem;
+  }
+
   .project-image {
     border-radius: 0.25rem;
     display: block;
@@ -506,14 +506,6 @@ export default class ProjectProfile extends Vue {
     border: none;
     color: $bg-primary-color;
     width: 100%;
-  }
-
-  .mb2 {
-    margin-bottom: 2rem;
-  }
-
-  .mt2 {
-    margin-top: 2rem;
   }
 }
 </style>

--- a/vue-app/src/components/RecipientSubmissionWidget.vue
+++ b/vue-app/src/components/RecipientSubmissionWidget.vue
@@ -24,13 +24,7 @@
         <div v-if="isWaiting" class="tx-notice">
           Check your wallet for a prompt...
         </div>
-        <div
-          v-if="hasTxError || isTxRejected"
-          class="warning-text"
-          style="font-size: 24px; margin-bottom: 0"
-        >
-          ⚠️
-        </div>
+        <div v-if="hasTxError || isTxRejected" class="warning-icon">⚠️</div>
         <div v-if="hasTxError" class="warning-text">
           Something failed: {{ txError }}<br />
           Check your wallet or Etherscan for more info.
@@ -468,15 +462,19 @@ export default class RecipientSubmissionWidget extends Vue {
   cursor: not-allowed;
 }
 
+.warning-icon {
+  font-size: 24px;
+}
+
 .warning-text {
-  margin-top: 0.25rem;
   font-size: 14px;
-  font-family: Inter;
-  margin-bottom: 2rem;
+}
+
+.warning-text,
+.warning-icon {
   line-height: 150%;
   color: $warning-color;
   text-transform: uppercase;
-  font-weight: 500;
   text-align: center;
 }
 </style>

--- a/vue-app/src/styles/_theme.scss
+++ b/vue-app/src/styles/_theme.scss
@@ -114,3 +114,19 @@
     background: $bg-hover;
   }
 }
+
+.token-icon {
+  margin-left: 0.5rem;
+}
+
+.big-emoji {
+  font-size: 4rem;
+}
+
+.mb2 {
+  margin-bottom: 2rem;
+}
+
+.mt2 {
+  margin-top: 2rem;
+}

--- a/vue-app/src/views/Join.vue
+++ b/vue-app/src/views/Join.vue
@@ -524,7 +524,6 @@
             <div v-if="!showSummaryPreview">
               <h2 class="step-title">Review your information</h2>
               <warning
-                style="margin-bottom: 1rem"
                 message="This information will be stored in a smart contract and cannot be edited, so please review carefully."
               />
               <div class="form-background">

--- a/vue-app/src/views/JoinLanding.vue
+++ b/vue-app/src/views/JoinLanding.vue
@@ -15,12 +15,12 @@
     </div>
 
     <div class="content" v-else-if="$store.getters.hasContributionPhaseEnded">
-      <div style="font-size: 64px">☹</div>
+      <div class="big-emoji">☹</div>
       <h1>Sorry, it's too late to join</h1>
       <div id="subtitle" class="subtitle">
         The round is closed for new projects. It's now too late to get on board.
       </div>
-      <div class="subtitle" id="subtitle" style="margin-top: 2rem">
+      <div class="subtitle mt2" id="subtitle">
         Check out these
         <links to="https://ethereum.org/en/community/grants/"
           >other ways to source funding</links
@@ -33,14 +33,14 @@
     </div>
 
     <div class="content" v-else-if="isRoundFull">
-      <div style="font-size: 64px">☹</div>
+      <div class="big-emoji">☹</div>
       <h1>Sorry, the round is full</h1>
       <div id="subtitle" class="subtitle">
         The tech we use to protect you from bribery and collusion, MACI, limits
         the number of projects right now. Unfortunately we've hit the cap and
         there's no more room on board.
       </div>
-      <div class="subtitle" id="subtitle" style="margin-top: 2rem">
+      <div class="subtitle mt2" id="subtitle">
         Check out these
         <links to="https://ethereum.org/en/community/grants/"
           >other ways to source funding</links
@@ -76,9 +76,7 @@
           <div class="countdown caps">15 minutes (ish)</div>
         </div>
         <div v-if="isRoundFillingUp" class="apply-callout-warning">
-          <div
-            style="display: flex; justify-content: space-between; align-items: flex-start;f"
-          >
+          <div class="filling-up-container">
             <div class="countdown caps">
               {{ spacesRemainingString }} left, hurry!
             </div>
@@ -91,7 +89,7 @@
               </div>
             </div>
           </div>
-          <p class="warning-text" style="margin-bottom: 0">
+          <p class="warning-text">
             You will get your deposit back if you don’t make it into the round
             this time.
           </p>
@@ -315,6 +313,16 @@ h1 {
   border-radius: 8px;
   padding: 1rem;
   margin-top: 1rem;
+}
+
+.filling-up-container {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+}
+
+.warning-text {
+  margin-bottom: 0;
 }
 
 .info-boxes {

--- a/vue-app/src/views/Profile.vue
+++ b/vue-app/src/views/Profile.vue
@@ -2,7 +2,7 @@
   <div class="wrapper">
     <div class="modal-background" @click="toggleProfile" />
     <div class="container">
-      <div class="flex-row" style="justify-content: flex-end">
+      <div class="flex-row flex-end">
         <div class="close-btn" @click="toggleProfile()">
           <p class="no-margin">Close</p>
           <img src="@/assets/close.svg" />
@@ -161,6 +161,11 @@ p.no-margin {
   justify-content: space-between;
   align-items: center;
 }
+
+.flex-end {
+  justify-content: flex-end;
+}
+
 .wrapper {
   position: fixed;
   top: 0;

--- a/vue-app/src/views/ProjectAdded.vue
+++ b/vue-app/src/views/ProjectAdded.vue
@@ -27,7 +27,7 @@
               criteria, we'll let you know by email and return your deposit.
             </li>
           </ul>
-          <div class="btn-container" style="margin-top: 2rem">
+          <div class="mt2">
             <links to="/projects" class="btn-primary">View projects</links>
             <links to="/" class="btn-secondary">Go home</links>
           </div>

--- a/vue-app/src/views/RecipientRegistry.vue
+++ b/vue-app/src/views/RecipientRegistry.vue
@@ -127,7 +127,7 @@
       </div>
     </div>
     <div v-else>
-      <div style="font-size: 64px" aria-label="hand">🤚</div>
+      <div class="big-emoji" aria-label="hand">🤚</div>
       <h2>
         You must be the recipient registry contract owner to access this page
       </h2>

--- a/vue-app/src/views/Verified.vue
+++ b/vue-app/src/views/Verified.vue
@@ -15,7 +15,7 @@
               <div class="etherscan-btn">
                 <img
                   class="icon"
-                  style="width: 16px"
+                  width="16px"
                   src="@/assets/etherscan.svg"
                 />Etherscan
               </div>
@@ -26,7 +26,7 @@
             – you’ll never have to do that again.
           </div>
           <p>You can now start contributing to your favourite projects.</p>
-          <div class="btn-container" style="margin-top: 2rem">
+          <div class="mt2">
             <links to="/projects" class="btn-primary">View projects</links>
             <links to="/" class="btn-secondary">Go home</links>
           </div>

--- a/vue-app/src/views/VerifyLanding.vue
+++ b/vue-app/src/views/VerifyLanding.vue
@@ -52,7 +52,7 @@
         The current round is no longer accepting new contributions. You can
         still get BrightID verified to prepare for next time.
       </div>
-      <div class="mt2">
+      <div class="btn-container mt2">
         <wallet-widget v-if="!currentUser" :isActionButton="true" />
         <links v-if="currentUser" to="/verify/connect" class="btn-primary">
           I have BrightID installed

--- a/vue-app/src/views/VerifyLanding.vue
+++ b/vue-app/src/views/VerifyLanding.vue
@@ -52,7 +52,7 @@
         The current round is no longer accepting new contributions. You can
         still get BrightID verified to prepare for next time.
       </div>
-      <div class="btn-container">
+      <div class="mt2">
         <wallet-widget v-if="!currentUser" :isActionButton="true" />
         <links v-if="currentUser" to="/verify/connect" class="btn-primary">
           I have BrightID installed
@@ -221,10 +221,6 @@ ul {
       position: relative;
       right: 0;
     }
-  }
-
-  .btn-container {
-    margin-top: 2rem;
   }
 }
 


### PR DESCRIPTION
- Extracts all instances of inline styling to CSS classes.
- Added a few recurrent single-purpose classes to `_theme.scss`
- Exceptions include dynamic styling that depends on props being passed to inline `style` attribute (ie: `IconStatus.vue` and `ProgressBar.vue`)