### PR TITLE
Fix sufficient balance check [Fixes #239]

### DIFF
--- a/vue-app/src/components/MatchingFundsModal.vue
+++ b/vue-app/src/components/MatchingFundsModal.vue
@@ -24,11 +24,8 @@
           />
         </div>
       </form>
-      <div
-        v-if="parseFloat(amount) > parseFloat(balance)"
-        class="balance-check-warning"
-      >
-        ⚠️ You only have {{ balance }} {{ tokenSymbol }}
+      <div v-if="!isBalanceSufficient" class="balance-check-warning">
+        ⚠️ You only have {{ renderBalance }} {{ tokenSymbol }}
       </div>
       <div class="btn-row">
         <button class="btn-secondary" @click="$emit('close')">Cancel</button>
@@ -104,7 +101,17 @@ export default class MatchingFundsModal extends Vue {
     if (balance === null || typeof balance === 'undefined') {
       return null
     }
-    return commify(formatUnits(balance, 18))
+    return formatUnits(balance, 18)
+  }
+
+  get renderBalance(): string | null {
+    if (this.balance === null) return null
+    return commify(this.balance)
+  }
+
+  get isBalanceSufficient(): boolean {
+    if (this.balance === null) return false
+    return parseFloat(this.balance) >= parseFloat(this.amount)
   }
 
   isRoundFinished(): boolean {


### PR DESCRIPTION
### Background:
Realized to reproduce issue #239 you need a token balance over 1000. This value was being run through `commify`, which outputs a string with commas if the number was big enough. 

ie. `commify` outputs `1,000`, and _then_ parsed with `parseFloat('1,000')` which improperly returns `1` when we needed `1000`.

(To reproduce locally, change two lines in `deployTestRound`: `const tokenInitialSupply = UNIT.mul(10000)` and `transferTx = await token.transfer(account.getAddress(), UNIT.mul(1000))` so the dummy accounts have more AOE)

### Fix:
Splits `balance` getter into `balance` and `renderBalance`... the first outputs the non-commified string, which is then used to check the value against the inputted contribution amount.  The other returns the commified form for rendering. 