### PR TITLE
Fixes link arrow color in help dropdown

### DIFF
--- a/vue-app/src/components/Links.vue
+++ b/vue-app/src/components/Links.vue
@@ -51,7 +51,6 @@ export default class extends Vue {
     content: '↗';
     transition: all 0.1s ease-in-out;
     font-style: normal;
-    /* color: white; */
   }
   &:hover {
     &:after {

--- a/vue-app/src/components/NavBar.vue
+++ b/vue-app/src/components/NavBar.vue
@@ -200,6 +200,9 @@ window.onclick = function (event) {
         padding: 0.5rem;
         gap: 0.5rem;
         width: 176px;
+        &:after {
+          color: $text-color;
+        }
         &:hover {
           background: $bg-light-color;
         }


### PR DESCRIPTION
`Links` component uses default coloring for links, which is purple in our theme. The 'Help' dropdown in the NavBar is styled white, but the external link arrow was showing up as purple still.

- This adds css selector for this component to style the `:after` pseudoelement white (`$text-color`) as well
- Also removes related unused CSS property from Links

![image](https://user-images.githubusercontent.com/54227730/130530211-7333608b-faaf-4def-b882-dfad78b6d008.png)
