### PR TITLE
Fixes `about-sybil-resistance` path

### DIFF
--- a/vue-app/src/router/index.ts
+++ b/vue-app/src/router/index.ts
@@ -167,11 +167,11 @@ const routes = [
     },
   },
   {
-    path: '/sybil-resistance',
-    name: 'sybil-resistance',
+    path: '/about-sybil-resistance',
+    name: 'about-sybil-resistance',
     component: AboutSybilResistance,
     meta: {
-      title: 'Sybil Resistance',
+      title: 'About Sybil Resistance',
     },
   },
   {

--- a/vue-app/src/views/VerifyLanding.vue
+++ b/vue-app/src/views/VerifyLanding.vue
@@ -47,7 +47,7 @@
         <li>An Ethereum wallet, with enough gas for two transactions</li>
         <li>Access to Zoom or Google Meet</li>
       </ul>
-      <links to="/sybil-resistance/">Why is this important?</links>
+      <links to="/about-sybil-resistance/">Why is this important?</links>
       <div v-if="isRoundFullOrOver" class="warning-message">
         The current round is no longer accepting new contributions. You can
         still get BrightID verified to prepare for next time.


### PR DESCRIPTION
Bug: "Sybil Resistance" link in Help dropdown leads to empty page. This is linked to `/about-sybil-resistance` which is inconsistent with the path for the `AboutSybilResistance` page component (was set to `/sybil-resistance`)

Fix: Updated the routing path to `/about-sybil-resistance` to keep consistent with the naming of the component, as well as the other `about-sybil-attacks` page. Updated the other internal link to this new path.