### PR TITLE
Keyboard accessibility

### DIFF
--- a/vue-app/src/components/Cart.vue
+++ b/vue-app/src/components/Cart.vue
@@ -678,7 +678,11 @@ export default class Cart extends Vue {
         ? ContributionModal
         : ReallocationModal,
       { votes },
-      { width: 500 }
+      {
+        width: 500,
+        clickToClose:
+          this.contribution.isZero() || !this.$store.getters.hasUserVoted,
+      }
     )
     this.$store.commit(TOGGLE_EDIT_SELECTION, false)
   }

--- a/vue-app/src/components/WalletModal.vue
+++ b/vue-app/src/components/WalletModal.vue
@@ -7,24 +7,26 @@
     <div v-else class="modal-body">
       <div class="top">
         <p>Connect to a wallet</p>
-        <img class="pointer" src="@/assets/close.svg" @click="$emit('close')" />
+        <button class="close-button" @click="$emit('close')">
+          <img class="pointer" src="@/assets/close.svg" />
+        </button>
       </div>
-      <div
+      <button
         v-if="windowEthereum"
         class="option"
         @click="connectWallet('metamask')"
       >
         <p>MetaMask</p>
         <img height="24px" width="24px" src="@/assets/metamask.png" />
-      </div>
-      <div v-else class="option" @click="redirectToMetamaskWebsite()">
+      </button>
+      <button v-else class="option" @click="redirectToMetamaskWebsite()">
         <p>Install MetaMask</p>
         <img height="24px" width="24px" src="@/assets/metamask.png" />
-      </div>
-      <div class="option" @click="connectWallet('walletconnect')">
+      </button>
+      <button class="option" @click="connectWallet('walletconnect')">
         <p>WalletConnect</p>
         <img height="24px" width="24px" src="@/assets/walletConnectIcon.svg" />
-      </div>
+      </button>
       <div v-if="error" class="error">{{ error }}</div>
     </div>
   </div>
@@ -108,6 +110,8 @@ export default class WalletModal extends Vue {
   display: flex;
   justify-content: space-between;
   align-items: center;
+  font-size: 16px;
+  color: $text-color;
   &:hover {
     cursor: pointer;
     border-color: $clr-green;
@@ -116,5 +120,10 @@ export default class WalletModal extends Vue {
   .btn-margin {
     margin-top: 16px;
   }
+}
+
+.close-button {
+  background: transparent;
+  border: none;
 }
 </style>

--- a/vue-app/src/main.ts
+++ b/vue-app/src/main.ts
@@ -12,7 +12,6 @@ Vue.use(Meta)
 Vue.use(VModal, {
   dynamicDefaults: {
     adaptive: true,
-    clickToClose: false,
     height: '100%',
     width: 450,
   },


### PR DESCRIPTION
Fixes: https://github.com/ethereum/clrfund/issues/274

**What changed**
- Made it so that modals can now be closed by hitting escape by changing vue-js-modal property: https://euvl.github.io/vue-js-modal/Properties.html#clicktoclose-boolean-default-true which was set to false
- Changed divs to buttons in WalletModal to allow for keyboard accessibility