### PR TITLE
Show users projects in wallet profile [Fixes #73]

### DIFF
--- a/vue-app/src/api/projects.ts
+++ b/vue-app/src/api/projects.ts
@@ -10,6 +10,7 @@ import KlerosRegistry from './recipient-registry-kleros'
 export interface Project {
   id: string // Address or another ID depending on registry implementation
   address: string
+  requester?: string
   name: string
   tagline?: string
   description: string

--- a/vue-app/src/api/recipient-registry-optimistic.ts
+++ b/vue-app/src/api/recipient-registry-optimistic.ts
@@ -317,6 +317,7 @@ function decodeProject(requestSubmittedEvent: Event): Project {
   return {
     id: args._recipientId,
     address: args._recipient,
+    requester: args._requester,
     name: metadata.name,
     description: metadata.description,
     imageUrl,

--- a/vue-app/src/components/BrightIdWidget.vue
+++ b/vue-app/src/components/BrightIdWidget.vue
@@ -43,10 +43,10 @@
             >
           </div>
           <div v-else>
-            <a href="/#/verify/" @click="toggleProfile">Continue setup</a>
+            <a href="/#/verify/" @click="$emit('close')">Continue setup</a>
           </div>
         </div>
-        <a href="/#/verify/" @click="toggleProfile" v-else>Start setup</a>
+        <a href="/#/verify/" @click="$emit('close')" v-else>Start setup</a>
         <p
           v-tooltip="{
             content: isVerified
@@ -77,7 +77,6 @@ export default class BrightIdWidget extends Vue {
   @Prop() abbrev!: string
   @Prop() balance!: string
   @Prop() isProjectCard!: boolean
-  @Prop() toggleProfile!: void
 
   get isLinked(): boolean {
     return (

--- a/vue-app/src/components/BrightIdWidget.vue
+++ b/vue-app/src/components/BrightIdWidget.vue
@@ -37,10 +37,10 @@
       <div class="row">
         <div v-if="isLinked">
           <div v-if="isRegistered">
-            <a href="/#/projects" @click="$emit('close')>
+            <a href="/#/projects" @click="$emit('close')">
               Start contributing
-              <span role="img" aria-label="party emoji">🎉</span></a
-            >
+              <span role="img" aria-label="party emoji">🎉</span>
+            </a>
           </div>
           <div v-else>
             <a href="/#/verify/" @click="$emit('close')">Continue setup</a>

--- a/vue-app/src/components/BrightIdWidget.vue
+++ b/vue-app/src/components/BrightIdWidget.vue
@@ -37,8 +37,8 @@
       <div class="row">
         <div v-if="isLinked">
           <div v-if="isRegistered">
-            <a href="/#/projects"
-              >Start contributing
+            <a href="/#/projects" @click="$emit('close')>
+              Start contributing
               <span role="img" aria-label="party emoji">🎉</span></a
             >
           </div>

--- a/vue-app/src/components/WalletWidget.vue
+++ b/vue-app/src/components/WalletWidget.vue
@@ -29,7 +29,6 @@
     </div>
     <profile
       v-if="showProfilePanel"
-      :toggleProfile="toggleProfile"
       :balance="balance"
       :etherBalance="etherBalance"
       @close="toggleProfile"
@@ -53,7 +52,6 @@ export default class WalletWidget extends Vue {
   private showProfilePanel: boolean | null = null
   profileImageUrl: string | null = null
   @Prop() showEth!: boolean
-
   // Boolean to only show Connect button, styled like an action button,
   // which hides the widget that would otherwise display after connecting
   @Prop() isActionButton!: boolean
@@ -88,7 +86,6 @@ export default class WalletWidget extends Vue {
 
   async mounted() {
     this.showProfilePanel = false
-
     this.$web3.$on('disconnect', () => {
       this.$store.dispatch(LOGOUT_USER)
     })

--- a/vue-app/src/components/WalletWidget.vue
+++ b/vue-app/src/components/WalletWidget.vue
@@ -32,6 +32,7 @@
       :toggleProfile="toggleProfile"
       :balance="balance"
       :etherBalance="etherBalance"
+      @close="toggleProfile"
     />
   </div>
 </template>

--- a/vue-app/src/store/index.ts
+++ b/vue-app/src/store/index.ts
@@ -458,6 +458,7 @@ const actions = {
 }
 
 const getters = {
+  // TODO generalize - this assumes optimistic registry
   recipientJoinDeadline: (state: RootState): DateTime | null => {
     if (!state.currentRound || !state.recipientRegistryInfo) {
       return null

--- a/vue-app/src/views/Profile.vue
+++ b/vue-app/src/views/Profile.vue
@@ -69,9 +69,9 @@
           </balance-item>
         </div>
       </div>
-      <div v-if="projects.length > 0" class="projects-section">
+      <div class="projects-section">
         <h2>Projects</h2>
-        <div class="project-list">
+        <div v-if="projects.length > 0" class="project-list">
           <div
             class="project-item"
             v-for="{
@@ -99,8 +99,11 @@
               {{ isLocked ? 'Preview' : 'View' }}
             </button>
           </div>
-          <loader v-if="isLoading" />
         </div>
+        <div v-if="!isLoading && projects.length === 0">
+          You haven't submitted any projects
+        </div>
+        <loader v-if="isLoading" />
       </div>
     </div>
   </div>

--- a/vue-app/src/views/Profile.vue
+++ b/vue-app/src/views/Profile.vue
@@ -363,7 +363,7 @@ p.no-margin {
         flex: 1;
         display: flex;
         flex-direction: column;
-        justify-content: space-between;
+        justify-content: center;
         padding: 0 1rem;
 
         .project-hidden {

--- a/vue-app/src/views/Profile.vue
+++ b/vue-app/src/views/Profile.vue
@@ -117,6 +117,8 @@ import BalanceItem from '@/components/BalanceItem.vue'
 import IconStatus from '@/components/IconStatus.vue'
 import BrightIdWidget from '@/components/BrightIdWidget.vue'
 import CopyButton from '@/components/CopyButton.vue'
+import Loader from '@/components/Loader.vue'
+
 import { LOGOUT_USER } from '@/store/action-types'
 import { User } from '@/api/user'
 import { userRegistryType, UserRegistryType } from '@/api/core'
@@ -125,7 +127,7 @@ import { CHAIN_INFO, ChainInfo } from '@/plugins/Web3/constants/chains'
 import { isSameAddress } from '@/utils/accounts'
 
 @Component({
-  components: { BalanceItem, BrightIdWidget, IconStatus, CopyButton },
+  components: { BalanceItem, BrightIdWidget, IconStatus, CopyButton, Loader },
 })
 export default class NavBar extends Vue {
   @Prop() balance!: string

--- a/vue-app/src/views/Profile.vue
+++ b/vue-app/src/views/Profile.vue
@@ -188,8 +188,10 @@ export default class NavBar extends Vue {
       currentRound?.startTime.toSeconds(),
       currentRound?.votingDeadline.toSeconds()
     )
-    const userProjects: Project[] = projects.filter(({ address }) =>
-      isSameAddress(address, currentUser?.walletAddress)
+    const userProjects: Project[] = projects.filter(
+      ({ address, requester }) =>
+        isSameAddress(address, currentUser?.walletAddress) ||
+        isSameAddress(requester as string, currentUser?.walletAddress)
     )
     this.projects = userProjects
   }

--- a/vue-app/src/views/Profile.vue
+++ b/vue-app/src/views/Profile.vue
@@ -346,7 +346,7 @@ p.no-margin {
       .project-thumbnail {
         width: 3rem;
         aspect-ratio: 1 / 1;
-        object-fit: fill;
+        object-fit: cover;
         border-radius: 0.5rem;
       }
       .project-details {

--- a/vue-app/src/views/Profile.vue
+++ b/vue-app/src/views/Profile.vue
@@ -244,14 +244,16 @@ p.no-margin {
   .container {
     position: absolute;
     right: 0;
+    top: 0;
+    bottom: 0;
     background: $bg-light-color;
-    height: 100%;
     width: clamp(350px, 25%, 500px);
     padding: 1.5rem;
     display: flex;
     flex-direction: column;
     gap: 1rem;
     z-index: 2;
+    overflow-y: scroll;
 
     .balances-card,
     .setup-card,

--- a/vue-app/src/views/Profile.vue
+++ b/vue-app/src/views/Profile.vue
@@ -1,9 +1,9 @@
 <template>
   <div class="wrapper">
-    <div class="modal-background" @click="toggleProfile" />
+    <div class="modal-background" @click="$emit('close')" />
     <div class="container">
       <div class="flex-row" style="justify-content: flex-end">
-        <div class="close-btn" @click="toggleProfile()">
+        <div class="close-btn" @click="$emit('close')">
           <p class="no-margin">Close</p>
           <img src="@/assets/close.svg" />
         </div>
@@ -36,7 +36,7 @@
       <bright-id-widget
         v-if="showBrightIdWidget"
         :isProjectCard="false"
-        :toggleProfile="toggleProfile"
+        @close="$emit('close')"
       />
       <div class="balances-section">
         <div class="flex-row">
@@ -125,7 +125,6 @@ import { isSameAddress } from '@/utils/accounts'
   components: { BalanceItem, BrightIdWidget, IconStatus, CopyButton },
 })
 export default class NavBar extends Vue {
-  @Prop() toggleProfile
   @Prop() balance!: string
   @Prop() etherBalance!: string
   projects: Project[] = []
@@ -177,7 +176,7 @@ export default class NavBar extends Vue {
       // Log out user
       this.$web3.disconnectWallet()
       this.$store.dispatch(LOGOUT_USER)
-      this.toggleProfile()
+      this.$emit('close')
     }
   }
 


### PR DESCRIPTION
### Description
- If currentUser is a recipient, display project info/status in the Profile component (within WalletWidget)
- Adds styling for `isLocked` and `isHidden` cases
- Links to project directly
- (Refactors the `toggleProfile` prop to an emitted 'close' event)

### Screenshot
![image](https://user-images.githubusercontent.com/54227730/131150989-314a8115-5d5a-401f-88fc-cf3c0f457b7c.png)

Open to suggested changes for handling the `isHidden` and `isLocked` states

### Related issue
Fixes #73
https://www.notion.so/efdn/Display-project-thumbnail-title-and-link-in-Profile-7d046a28d5fd43cd8eb0275d65d23915

Fixes: https://github.com/ethereum/clrfund/issues/311