### PR TITLE
Adds ENS support

### DIFF
--- a/vue-app/.env.example
+++ b/vue-app/.env.example
@@ -1,3 +1,7 @@
+# Ethereum Mainnet provider (used for ENS lookups)
+VUE_APP_ETHEREUM_MAINNET_API_URL=https://mainnet.infura.io/v3/ADD_API_KEY
+
+# Chain details where contract is deployed
 VUE_APP_ETHEREUM_API_URL=http://localhost:18545
 VUE_APP_ETHEREUM_API_CHAINID=31337
 VUE_APP_INFURA_ID=

--- a/vue-app/src/api/core.ts
+++ b/vue-app/src/api/core.ts
@@ -2,6 +2,9 @@ import { ethers } from 'ethers'
 
 import { FundingRoundFactory } from './abi'
 
+export const mainnetProvider = new ethers.providers.StaticJsonRpcProvider(
+  process.env.VUE_APP_MAINNET_PROVIDER_URL
+)
 export const provider = new ethers.providers.StaticJsonRpcProvider(
   process.env.VUE_APP_ETHEREUM_API_URL
 )

--- a/vue-app/src/api/core.ts
+++ b/vue-app/src/api/core.ts
@@ -3,7 +3,7 @@ import { ethers } from 'ethers'
 import { FundingRoundFactory } from './abi'
 
 export const mainnetProvider = new ethers.providers.StaticJsonRpcProvider(
-  process.env.VUE_APP_MAINNET_PROVIDER_URL
+  process.env.VUE_APP_ETHEREUM_MAINNET_API_URL
 )
 export const provider = new ethers.providers.StaticJsonRpcProvider(
   process.env.VUE_APP_ETHEREUM_API_URL

--- a/vue-app/src/api/projects.ts
+++ b/vue-app/src/api/projects.ts
@@ -10,6 +10,7 @@ import KlerosRegistry from './recipient-registry-kleros'
 export interface Project {
   id: string // Address or another ID depending on registry implementation
   address: string
+  requester?: string
   name: string
   tagline?: string
   description: string

--- a/vue-app/src/api/recipient-registry-optimistic.ts
+++ b/vue-app/src/api/recipient-registry-optimistic.ts
@@ -91,6 +91,7 @@ export interface RecipientApplicationData {
     thumbnailHash: string
   }
   furthestStep: number
+  hasEns: boolean
 }
 
 export function formToProjectInterface(

--- a/vue-app/src/api/recipient-registry-optimistic.ts
+++ b/vue-app/src/api/recipient-registry-optimistic.ts
@@ -70,7 +70,8 @@ export interface RecipientApplicationData {
     problemSpace: string
   }
   fund: {
-    address: string
+    addressName: string
+    resolvedAddress: string
     plans: string
   }
   team: {
@@ -97,8 +98,8 @@ export function formToProjectInterface(
 ): Project {
   const { project, fund, team, links, image } = data
   return {
-    id: fund.address,
-    address: fund.address,
+    id: fund.resolvedAddress,
+    address: fund.resolvedAddress,
     name: project.name,
     tagline: project.tagline,
     description: project.description,
@@ -256,7 +257,7 @@ export function formToRecipientData(
 ): RecipientData {
   const { project, fund, team, links, image } = data
   return {
-    address: fund.address,
+    address: fund.resolvedAddress,
     name: project.name,
     tagline: project.tagline,
     description: project.description,

--- a/vue-app/src/api/recipient-registry-optimistic.ts
+++ b/vue-app/src/api/recipient-registry-optimistic.ts
@@ -319,6 +319,7 @@ function decodeProject(requestSubmittedEvent: Event): Project {
   return {
     id: args._recipientId,
     address: args._recipient,
+    requester: args._requester,
     name: metadata.name,
     description: metadata.description,
     imageUrl,

--- a/vue-app/src/api/user.ts
+++ b/vue-app/src/api/user.ts
@@ -23,6 +23,7 @@ export interface User {
   balance?: BigNumber | null
   etherBalance?: BigNumber | null
   contribution?: BigNumber | null
+  ensName?: string | null
 }
 
 export async function getProfileImageUrl(

--- a/vue-app/src/components/ProjectProfile.vue
+++ b/vue-app/src/components/ProjectProfile.vue
@@ -14,7 +14,7 @@
     <div class="about">
       <h1
         class="project-name"
-        :title="project.address"
+        :title="addressName"
         :project-index="project.index"
       >
         <links v-if="klerosCurateUrl" :to="klerosCurateUrl">{{
@@ -93,7 +93,7 @@
         <div>
           <div class="address-label">Recipient address</div>
           <div class="address">
-            {{ project.address }}
+            {{ addressName }}
           </div>
         </div>
         <div class="copy-div">
@@ -136,14 +136,15 @@ import { FixedNumber } from 'ethers'
 import { Tally } from '@/api/tally'
 import { getAllocatedAmount, isFundsClaimed } from '@/api/claims'
 import { Project } from '@/api/projects'
-import Info from '@/components/Info.vue'
-import Markdown from '@/components/Markdown.vue'
-import CopyButton from '@/components/CopyButton.vue'
 import { DEFAULT_CONTRIBUTION_AMOUNT, CartItem } from '@/api/contributions'
 import { RoundStatus } from '@/api/round'
 import { blockExplorer } from '@/api/core'
 import { SAVE_CART } from '@/store/action-types'
 import { ADD_CART_ITEM } from '@/store/mutation-types'
+import { ensLookup } from '@/utils/accounts'
+import Info from '@/components/Info.vue'
+import Markdown from '@/components/Markdown.vue'
+import CopyButton from '@/components/CopyButton.vue'
 import ClaimModal from '@/components/ClaimModal.vue'
 import LinkBox from '@/components/LinkBox.vue'
 import Links from '@/components/Links.vue'
@@ -156,6 +157,13 @@ export default class ProjectProfile extends Vue {
   @Prop() project!: Project
   @Prop() klerosCurateUrl!: string | null
   @Prop() previewMode!: boolean
+  ens: string | null = null
+
+  async mounted() {
+    if (this.project.address) {
+      this.ens = await ensLookup(this.project.address)
+    }
+  }
 
   private async checkAllocation(tally: Tally | null) {
     const currentRound = this.$store.state.currentRound
@@ -263,6 +271,10 @@ export default class ProjectProfile extends Vue {
 
   get blockExplorerUrl(): string {
     return `${blockExplorer}/address/${this.project.address}`
+  }
+
+  get addressName(): string {
+    return this.ens || this.project.address
   }
 }
 </script>

--- a/vue-app/src/components/WalletWidget.vue
+++ b/vue-app/src/components/WalletWidget.vue
@@ -21,7 +21,7 @@
         <div v-if="showEth" class="balance">{{ etherBalance }}</div>
       </div>
       <div class="profile-name">
-        {{ renderUserAddress(7) }}
+        {{ displayAddress }}
       </div>
       <div class="profile-image">
         <img v-if="profileImageUrl" :src="profileImageUrl" />
@@ -122,23 +122,9 @@ export default class WalletWidget extends Vue {
     }
   }
 
-  // TODO: Extract into a shared function
-  renderUserAddress(digitsToShow?: number): string {
-    if (this.currentUser?.walletAddress) {
-      const address: string = this.currentUser.walletAddress
-      if (digitsToShow) {
-        const beginDigits: number = Math.ceil(digitsToShow / 2)
-        const endDigits: number = Math.floor(digitsToShow / 2)
-        const begin: string = address.substr(0, 2 + beginDigits)
-        const end: string = address.substr(
-          address.length - endDigits,
-          endDigits
-        )
-        return `${begin}…${end}`
-      }
-      return address
-    }
-    return ''
+  get displayAddress(): string | null {
+    if (!this.currentUser) return null
+    return this.currentUser.ensName ?? this.currentUser.walletAddress
   }
 }
 </script>
@@ -165,6 +151,9 @@ export default class WalletWidget extends Vue {
   .profile-name {
     font-size: 14px;
     opacity: 0.8;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: min(20vw, 14ch);
   }
 
   .balance {

--- a/vue-app/src/store/index.ts
+++ b/vue-app/src/store/index.ts
@@ -78,10 +78,11 @@ import {
 } from './mutation-types'
 
 // Utils
-import { isSameAddress } from '@/utils/accounts'
+import { isSameAddress, ensLookup } from '@/utils/accounts'
 import { getSecondsFromNow, hasDateElapsed } from '@/utils/dates'
 import { UserRegistryType, userRegistryType } from '@/api/core'
 import { BrightId, getBrightId } from '@/api/bright-id'
+import { isAddress } from 'ethers/lib/utils'
 
 Vue.use(Vuex)
 
@@ -327,11 +328,17 @@ const actions = {
         }
       }
 
+      let ensName: string | null = state.currentUser.ensName
+      if (isAddress(state.currentUser.walletAddress)) {
+        ensName = await ensLookup(state.currentUser.walletAddress)
+      }
+
       commit(SET_CURRENT_USER, {
         ...state.currentUser,
         isRegistered,
         balance,
         etherBalance,
+        ensName,
       })
     }
   },

--- a/vue-app/src/store/index.ts
+++ b/vue-app/src/store/index.ts
@@ -329,9 +329,7 @@ const actions = {
       }
 
       let ensName: string | null = state.currentUser.ensName
-      if (isAddress(state.currentUser.walletAddress)) {
-        ensName = await ensLookup(state.currentUser.walletAddress)
-      }
+      ensName = await ensLookup(state.currentUser.walletAddress)
 
       commit(SET_CURRENT_USER, {
         ...state.currentUser,

--- a/vue-app/src/utils/accounts.ts
+++ b/vue-app/src/utils/accounts.ts
@@ -19,12 +19,6 @@ export async function resolveEns(name: string): Promise<string | null> {
   return await mainnetProvider.resolveName(name)
 }
 
-export async function isValidEns(name: string): Promise<boolean> {
-  // Only returns true if name is valid ENS (not 0x address)
-  const address: string | null = await resolveEns(name)
-  return !!address
-}
-
 export async function isValidEthAddress(address: string): Promise<boolean> {
   // Returns true if address is valid ENS or 0x address
   const resolved = await mainnetProvider.resolveName(address)

--- a/vue-app/src/utils/accounts.ts
+++ b/vue-app/src/utils/accounts.ts
@@ -1,5 +1,11 @@
 import { ethers } from 'ethers'
+import { mainnetProvider } from '@/api/core'
 
 export function isSameAddress(address1: string, address2: string): boolean {
   return ethers.utils.getAddress(address1) === ethers.utils.getAddress(address2)
+}
+
+export async function ensLookup(address: string): Promise<string | null> {
+  const ens = await mainnetProvider.lookupAddress(address)
+  return ens
 }

--- a/vue-app/src/utils/accounts.ts
+++ b/vue-app/src/utils/accounts.ts
@@ -9,3 +9,13 @@ export async function ensLookup(address: string): Promise<string | null> {
   const ens = await mainnetProvider.lookupAddress(address)
   return ens
 }
+
+export async function isValidEns(name: string): Promise<boolean> {
+  const address = await mainnetProvider.resolveName(name)
+  return !!address
+}
+
+export async function resolveEns(name: string): Promise<string | null> {
+  const address = await mainnetProvider.resolveName(name)
+  return address
+}

--- a/vue-app/src/utils/accounts.ts
+++ b/vue-app/src/utils/accounts.ts
@@ -6,21 +6,21 @@ export function isSameAddress(address1: string, address2: string): boolean {
   return ethers.utils.getAddress(address1) === ethers.utils.getAddress(address2)
 }
 
+// Looks up possible ENS for given 0x address
 export async function ensLookup(address: string): Promise<string | null> {
-  // Looks up possible ENS for given 0x address
   const name: string | null = await mainnetProvider.lookupAddress(address)
   return name
 }
 
+// Returns null if the name passed is a 0x address
+// If name is valid ENS returns 0x address, else returns null
 export async function resolveEns(name: string): Promise<string | null> {
-  // Returns null if the name passed is a 0x address
   if (isAddress(name)) return null
-  // If name is valid ENS returns 0x address, else returns null
   return await mainnetProvider.resolveName(name)
 }
 
+// Returns true if address is valid ENS or 0x address
 export async function isValidEthAddress(address: string): Promise<boolean> {
-  // Returns true if address is valid ENS or 0x address
   const resolved = await mainnetProvider.resolveName(address)
   return !!resolved
 }

--- a/vue-app/src/utils/accounts.ts
+++ b/vue-app/src/utils/accounts.ts
@@ -1,21 +1,32 @@
 import { ethers } from 'ethers'
 import { mainnetProvider } from '@/api/core'
+import { isAddress } from '@ethersproject/address'
 
 export function isSameAddress(address1: string, address2: string): boolean {
   return ethers.utils.getAddress(address1) === ethers.utils.getAddress(address2)
 }
 
 export async function ensLookup(address: string): Promise<string | null> {
-  const ens = await mainnetProvider.lookupAddress(address)
-  return ens
-}
-
-export async function isValidEns(name: string): Promise<boolean> {
-  const address = await mainnetProvider.resolveName(name)
-  return !!address
+  // Looks up possible ENS for given 0x address
+  const name: string | null = await mainnetProvider.lookupAddress(address)
+  return name
 }
 
 export async function resolveEns(name: string): Promise<string | null> {
-  const address = await mainnetProvider.resolveName(name)
-  return address
+  // Returns null if the name passed is a 0x address
+  if (isAddress(name)) return null
+  // If name is valid ENS returns 0x address, else returns null
+  return await mainnetProvider.resolveName(name)
+}
+
+export async function isValidEns(name: string): Promise<boolean> {
+  // Only returns true if name is valid ENS (not 0x address)
+  const address: string | null = await resolveEns(name)
+  return !!address
+}
+
+export async function isValidEthAddress(address: string): Promise<boolean> {
+  // Returns true if address is valid ENS or 0x address
+  const resolved = await mainnetProvider.resolveName(address)
+  return !!resolved
 }

--- a/vue-app/src/views/Join.vue
+++ b/vue-app/src/views/Join.vue
@@ -306,11 +306,9 @@
                     round.
                   </p>
                   <input
-                    required
                     id="team-email"
                     placeholder="example: doge@goodboi.com"
-                    v-model="form.team.email"
-                    @blur="$v.form.team.email.$touch()"
+                    v-model.lazy="$v.form.team.email.$model"
                     :class="{
                       input: true,
                       invalid: $v.form.team.email.$error,
@@ -381,8 +379,7 @@
                     id="links-github"
                     type="link"
                     placeholder="example: https://github.com/ethereum/clrfund"
-                    class="input"
-                    v-model="$v.form.links.github.$model"
+                    v-model.lazy="$v.form.links.github.$model"
                     :class="{
                       input: true,
                       invalid: $v.form.links.github.$error,
@@ -404,8 +401,7 @@
                     id="links-radicle"
                     type="link"
                     placeholder="example: https://radicle.com/ethereum/clrfund"
-                    class="input"
-                    v-model="$v.form.links.radicle.$model"
+                    v-model.lazy="$v.form.links.radicle.$model"
                     :class="{
                       input: true,
                       invalid: $v.form.links.radicle.$error,
@@ -426,8 +422,7 @@
                     id="links-website"
                     type="link"
                     placeholder="example: https://ethereum.foundation"
-                    class="input"
-                    v-model="$v.form.links.website.$model"
+                    v-model.lazy="$v.form.links.website.$model"
                     :class="{
                       input: true,
                       invalid: $v.form.links.website.$error,
@@ -448,8 +443,7 @@
                     id="links-twitter"
                     type="link"
                     placeholder="example: https://twitter.com/ethereum"
-                    class="input"
-                    v-model="$v.form.links.twitter.$model"
+                    v-model.lazy="$v.form.links.twitter.$model"
                     :class="{
                       input: true,
                       invalid: $v.form.links.twitter.$error,
@@ -471,7 +465,7 @@
                     type="link"
                     placeholder="example: https://discord.gg/5Prub9zbGz"
                     class="input"
-                    v-model="$v.form.links.discord.$model"
+                    v-model.lazy="$v.form.links.discord.$model"
                     :class="{
                       input: true,
                       invalid: $v.form.links.discord.$error,

--- a/vue-app/src/views/Join.vue
+++ b/vue-app/src/views/Join.vue
@@ -565,6 +565,13 @@
                       View on Etherscan
                     </links>
                   </div>
+                  <div
+                    class="resolved-address"
+                    v-if="form.fund.addressName"
+                    title="Resolved ENS address"
+                  >
+                    {{ form.hasEns ? form.fund.resolvedAddress : null }}
+                  </div>
                 </div>
                 <div class="summary">
                   <h4 class="read-only-title">Funding plans</h4>
@@ -736,8 +743,7 @@ import Component, { mixins } from 'vue-class-component'
 import { validationMixin } from 'vuelidate'
 import { required, maxLength, url, email } from 'vuelidate/lib/validators'
 import * as isIPFS from 'is-ipfs'
-import { isAddress } from '@ethersproject/address'
-import { isValidEns, resolveEns } from '@/utils/accounts'
+import { isValidEthAddress, resolveEns } from '@/utils/accounts'
 import LayoutSteps from '@/components/LayoutSteps.vue'
 import ProgressBar from '@/components/ProgressBar.vue'
 import FormNavigation from '@/components/FormNavigation.vue'
@@ -789,7 +795,7 @@ import { blockExplorer } from '@/api/core'
       fund: {
         addressName: {
           required,
-          validEthAddress: (e) => isAddress(e) || isValidEns(e),
+          validEthAddress: isValidEthAddress,
         },
         resolvedAddress: {},
         plans: { required },
@@ -853,6 +859,7 @@ export default class JoinView extends mixins(validationMixin) {
       thumbnailHash: '',
     },
     furthestStep: 0,
+    hasEns: false,
   }
   currentStep = 0
   steps: string[] = []
@@ -1024,7 +1031,8 @@ export default class JoinView extends mixins(validationMixin) {
   async checkEns(): Promise<void> {
     const { addressName } = this.form?.fund
     if (addressName) {
-      const res = await resolveEns(addressName)
+      const res: string | null = await resolveEns(addressName)
+      this.form.hasEns = !!res
       this.form.fund.resolvedAddress = res ? res : addressName
     }
   }
@@ -1529,5 +1537,14 @@ export default class JoinView extends mixins(validationMixin) {
 
 .no-break {
   white-space: nowrap;
+}
+
+.resolved-address {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  opacity: 0.5;
+  word-break: keep-all;
+  font-size: 0.875rem;
+  margin-top: 0.25rem;
 }
 </style>

--- a/vue-app/src/views/Profile.vue
+++ b/vue-app/src/views/Profile.vue
@@ -249,7 +249,7 @@ p.no-margin {
     background: $bg-light-color;
     padding: 1.5rem;
     box-sizing: border-box;
-    width: clamp(min(414px, 100%), 25%, 500px);
+    width: clamp(min(414px, 100%), 35%, 500px);
     display: flex;
     flex-direction: column;
     gap: 1rem;

--- a/vue-app/src/views/Profile.vue
+++ b/vue-app/src/views/Profile.vue
@@ -21,7 +21,7 @@
             class="copy"
           />
           <div class="address">
-            {{ ens ? currentUser.walletAddress : null }}
+            {{ currentUser.ensName ? currentUser.walletAddress : null }}
           </div>
           <div
             v-tooltip="{
@@ -137,9 +137,9 @@ export default class NavBar extends Vue {
   async created() {
     this.isLoading = true
     await this.loadProjects()
-    if (this.currentUser) {
-      this.ens = await ensLookup(this.currentUser.walletAddress)
-    }
+    // if (this.currentUser) {
+    //   this.ens = await ensLookup(this.currentUser.walletAddress)
+    // }
     this.isLoading = false
   }
 
@@ -161,7 +161,7 @@ export default class NavBar extends Vue {
 
   get displayAddress(): string | null {
     if (!this.currentUser) return null
-    return this.ens ?? this.currentUser.walletAddress
+    return this.currentUser.ensName ?? this.currentUser.walletAddress
   }
 
   async disconnect(): Promise<void> {

--- a/vue-app/src/views/Profile.vue
+++ b/vue-app/src/views/Profile.vue
@@ -121,7 +121,7 @@ import { User } from '@/api/user'
 import { userRegistryType, UserRegistryType } from '@/api/core'
 import { Project, getProjects } from '@/api/projects'
 import { CHAIN_INFO, ChainInfo } from '@/plugins/Web3/constants/chains'
-import { isSameAddress, ensLookup } from '@/utils/accounts'
+import { isSameAddress } from '@/utils/accounts'
 
 @Component({
   components: { BalanceItem, BrightIdWidget, IconStatus, CopyButton },
@@ -132,14 +132,10 @@ export default class NavBar extends Vue {
   projects: Project[] = []
   balanceBackgroundColor = '#2a374b'
   isLoading = true
-  ens: string | null = null
 
   async created() {
     this.isLoading = true
     await this.loadProjects()
-    // if (this.currentUser) {
-    //   this.ens = await ensLookup(this.currentUser.walletAddress)
-    // }
     this.isLoading = false
   }
 

--- a/vue-app/src/views/Profile.vue
+++ b/vue-app/src/views/Profile.vue
@@ -177,8 +177,10 @@ export default class NavBar extends Vue {
       currentRound?.startTime.toSeconds(),
       currentRound?.votingDeadline.toSeconds()
     )
-    const userProjects: Project[] = projects.filter(({ address }) =>
-      isSameAddress(address, currentUser?.walletAddress)
+    const userProjects: Project[] = projects.filter(
+      ({ address, requester }) =>
+        isSameAddress(address, currentUser?.walletAddress) ||
+        isSameAddress(requester as string, currentUser?.walletAddress)
     )
     this.projects = userProjects
   }

--- a/vue-app/src/views/Profile.vue
+++ b/vue-app/src/views/Profile.vue
@@ -247,8 +247,9 @@ p.no-margin {
     top: 0;
     bottom: 0;
     background: $bg-light-color;
-    width: clamp(350px, 25%, 500px);
     padding: 1.5rem;
+    box-sizing: border-box;
+    width: clamp(min(414px, 100%), 25%, 500px);
     display: flex;
     flex-direction: column;
     gap: 1rem;


### PR DESCRIPTION
🚨 `wallet-projects` (PR #307) <- `profile-layout`
https://www.notion.so/efdn/Display-user-s-ENS-address-once-connected-9aeaf51a811a4573be25a1a2852cd4f1

### Description
- Adds ENS related functions to `/utils/accounts` (utilizes `VUE_APP_MAINNET_PROVIDER_URL` .env variable)
- Looks up possible ENS for current user address upon loading/setting user (`LOAD_USER_INFO`)
- `ensName` property added to `User` interface to store this data
- Updated Profile and WalletWidget to show ENS if available. In Profile, if no ENS available, redundant 0x address is hidden. 
- Layout adjustments for Profile on mobile
- Restyles addresses to use `text-overflow: ellipsis;` to improve responsiveness and flexibility

**Join** form changes:
- Adds ENS support to team funding address input.
- Utilizes `v-model.lazy` to only validate this field upon leaving/blurring to prevent ENS queries on every keystroke.
- Applied this same `.lazy` approach to existing issues with "email" input (only validates now after user leaves). 
- Form summary shows ENS if available, and in that case also shows the corresponding address dimmed below for confirmation.
- ProjectProfile used for displaying project and project preview shows the ENS address if available, but link and copy button reference the resolved 0x address.

### Screenshots
![image](https://user-images.githubusercontent.com/54227730/131199802-f5c01555-6a73-4831-9a8d-a608a52e2773.png)
![image](https://user-images.githubusercontent.com/54227730/131199838-853533be-e7c3-4a57-a455-e8670e6d42d6.png)

