### PR TITLE
Mobile - Cart total bar covering scrollable content

### DIFF
--- a/vue-app/src/components/Cart.vue
+++ b/vue-app/src/components/Cart.vue
@@ -774,6 +774,7 @@ h2 {
   }
   @media (max-width: $breakpoint-s) {
     padding: 1rem 0rem;
+    margin-bottom: 3rem;
   }
 }
 
@@ -1059,7 +1060,6 @@ h2 {
     padding-left: 0;
     padding-right: 0;
     width: 100%;
-    margin-bottom: 1rem;
   }
 }
 

--- a/vue-app/src/components/Cart.vue
+++ b/vue-app/src/components/Cart.vue
@@ -814,6 +814,7 @@ h2 {
   align-items: flex-end;
   justify-content: space-between;
   width: 100%;
+  margin-top: 1rem;
 }
 
 .time-left-read-only {


### PR DESCRIPTION
Fixes: https://github.com/ethereum/clrfund/issues/300

**What changed**
- Added margin in for mobile view to allow for some more scrolling
- Shifted where the margin for time-left for consistency in the div padding