### PR TITLE
Mobile - BrightID info hard to read

### DIFF
--- a/vue-app/src/views/VerifyLanding.vue
+++ b/vue-app/src/views/VerifyLanding.vue
@@ -209,6 +209,14 @@ ul {
     padding-bottom: 35vw;
   }
 
+  @media (max-width: $breakpoint-s) {
+    background: linear-gradient(
+      171.34deg,
+      rgba(0, 0, 0, 0.8) 63.5%,
+      rgba(196, 196, 196, 0) 78.75%
+    );
+  }
+
   .flex-title {
     display: flex;
     gap: 0.5rem;


### PR DESCRIPTION
Fixes: https://github.com/ethereum/clrfund/issues/301

**What Changed**
- Added background gradient when in mobile breakpoint to make text legible