### PR TITLE
Passes tx hash as route param to Verified component [Fixes #310]

### DIFF
--- a/vue-app/src/router/index.ts
+++ b/vue-app/src/router/index.ts
@@ -127,7 +127,7 @@ const routes = [
     },
   },
   {
-    path: '/verify/success',
+    path: '/verify/success/:hash',
     name: 'verified',
     component: Verified,
     meta: {

--- a/vue-app/src/views/TransactionSuccess.vue
+++ b/vue-app/src/views/TransactionSuccess.vue
@@ -47,7 +47,7 @@
           to reallocate your contributions.
         </p>
         <div class="receipt" v-if="$route.params.hash">
-          <transaction-receipt :hash="`${$route.params.hash}`" />
+          <transaction-receipt :hash="$route.params.hash" />
         </div>
         <div class="input-button">
           <button class="contributed-button" @click="redirectToProjects()">

--- a/vue-app/src/views/Verified.vue
+++ b/vue-app/src/views/Verified.vue
@@ -11,15 +11,7 @@
           <span class="emoji">🎉</span>
           <div class="flex-title">
             <h1>Ready to contribute!</h1>
-            <links v-if="$route.params.hash" :to="blockExplorerUrl">
-              <div class="etherscan-btn">
-                <img
-                  class="icon"
-                  width="16px"
-                  src="@/assets/etherscan.svg"
-                />Etherscan
-              </div>
-            </links>
+            <transaction-receipt :hash="$route.params.hash" />
           </div>
           <div class="subtitle">
             You’re on board this funding round! And fully verified for BrightID
@@ -43,10 +35,12 @@ import * as humanizeDuration from 'humanize-duration'
 import ProgressBar from '@/components/ProgressBar.vue'
 import RoundStatusBanner from '@/components/RoundStatusBanner.vue'
 import Links from '@/components/Links.vue'
-
+import TransactionReceipt from '@/components/TransactionReceipt.vue'
 import { blockExplorer } from '@/api/core'
 
-@Component({ components: { ProgressBar, RoundStatusBanner, Links } })
+@Component({
+  components: { ProgressBar, RoundStatusBanner, Links, TransactionReceipt },
+})
 export default class Verified extends Vue {
   get blockExplorerUrl(): string {
     return `${blockExplorer}/tx/${this.$route.params.hash}`

--- a/vue-app/src/views/Verified.vue
+++ b/vue-app/src/views/Verified.vue
@@ -11,7 +11,7 @@
           <span class="emoji">🎉</span>
           <div class="flex-title">
             <h1>Ready to contribute!</h1>
-            <links v-if="txHash" :to="blockExplorerUrl">
+            <links v-if="$route.params.hash" :to="blockExplorerUrl">
               <div class="etherscan-btn">
                 <img
                   class="icon"
@@ -48,12 +48,8 @@ import { blockExplorer } from '@/api/core'
 
 @Component({ components: { ProgressBar, RoundStatusBanner, Links } })
 export default class Verified extends Vue {
-  // TODO: Retrieve hash of transaction.
-  // We route to this component, pass hash as queryParam after submission?
-  txHash = '0xfakehashf7261d65be24e7f5cabefba4a659e1e2e13685cc03ad87233ee2713d'
-
   get blockExplorerUrl(): string {
-    return `${blockExplorer}/tx/${this.txHash}`
+    return `${blockExplorer}/tx/${this.$route.params.hash}`
   }
 
   formatDuration(value: number): string {

--- a/vue-app/src/views/Verified.vue
+++ b/vue-app/src/views/Verified.vue
@@ -31,25 +31,15 @@
 <script lang="ts">
 import Vue from 'vue'
 import Component from 'vue-class-component'
-import * as humanizeDuration from 'humanize-duration'
 import ProgressBar from '@/components/ProgressBar.vue'
 import RoundStatusBanner from '@/components/RoundStatusBanner.vue'
 import Links from '@/components/Links.vue'
 import TransactionReceipt from '@/components/TransactionReceipt.vue'
-import { blockExplorer } from '@/api/core'
 
 @Component({
   components: { ProgressBar, RoundStatusBanner, Links, TransactionReceipt },
 })
-export default class Verified extends Vue {
-  get blockExplorerUrl(): string {
-    return `${blockExplorer}/tx/${this.$route.params.hash}`
-  }
-
-  formatDuration(value: number): string {
-    return humanizeDuration(value * 1000, { largest: 1 })
-  }
-}
+export default class Verified extends Vue {}
 </script>
 
 <style scoped lang="scss">

--- a/vue-app/src/views/Verify.vue
+++ b/vue-app/src/views/Verify.vue
@@ -353,7 +353,10 @@ export default class VerifyView extends Vue {
           (hash) => (this.registrationTxHash = hash)
         )
         this.loadingTx = false
-        this.$router.push({ name: 'verified' })
+        this.$router.push({
+          name: 'verified',
+          params: { hash: this.registrationTxHash },
+        })
       } catch (error) {
         this.registrationTxError = error.message
         return


### PR DESCRIPTION
### Description
- Upon completion of BrightID verification, the tx hash is passed when navigating to the Verified component (`/verify/success/:hash`)
- Hash is then used to properly link to block explorer

### Related issues
[Fixes #310]