### PR TITLE
Adds `renderTokenAmount` helper [Fixes #327]

### DIFF
--- a/vue-app/src/components/WalletWidget.vue
+++ b/vue-app/src/components/WalletWidget.vue
@@ -82,7 +82,7 @@ export default class WalletWidget extends Vue {
     if (balance === null || typeof balance === 'undefined') {
       return null
     }
-    return renderTokenAmount(balance, 2)
+    return renderTokenAmount(balance, 5)
   }
 
   async mounted() {

--- a/vue-app/src/components/WalletWidget.vue
+++ b/vue-app/src/components/WalletWidget.vue
@@ -40,8 +40,8 @@
 import Vue from 'vue'
 import Component from 'vue-class-component'
 import { Prop, Watch } from 'vue-property-decorator'
-import { commify, formatUnits } from '@ethersproject/units'
 
+import { renderTokenAmount } from '@/utils/amounts'
 import { User, getProfileImageUrl } from '@/api/user'
 import WalletModal from '@/components/WalletModal.vue'
 import { LOGOUT_USER } from '@/store/action-types'
@@ -74,7 +74,7 @@ export default class WalletWidget extends Vue {
     if (etherBalance === null || typeof etherBalance === 'undefined') {
       return null
     }
-    return commify(formatUnits(etherBalance, 'ether'))
+    return renderTokenAmount(etherBalance, 5, 'ether')
   }
 
   get balance(): string | null {
@@ -82,7 +82,7 @@ export default class WalletWidget extends Vue {
     if (balance === null || typeof balance === 'undefined') {
       return null
     }
-    return commify(formatUnits(balance, 18))
+    return renderTokenAmount(balance, 2)
   }
 
   async mounted() {

--- a/vue-app/src/utils/amounts.ts
+++ b/vue-app/src/utils/amounts.ts
@@ -1,5 +1,36 @@
-import { BigNumber, FixedNumber } from 'ethers'
+import { BigNumber, BigNumberish, FixedNumber } from 'ethers'
+import { commify, formatUnits } from '@ethersproject/units'
 
 export function formatAmount(value: BigNumber, decimals: number): string {
   return FixedNumber.fromValue(value, decimals).toString()
+}
+
+export function renderTokenAmount(
+  amount: BigNumber,
+  maxDecimals: number,
+  unitName: BigNumberish = 18
+): string {
+  let result: string
+
+  // Convert smaller units (really large integers) to whole AOE balance (human readable floats)
+  let unitsFormatted: string = formatUnits(amount, unitName).toString()
+  // Whole numbers return with single trailing zero decimal; remove this
+  if (unitsFormatted.substring(unitsFormatted.length - 2) === '.0') {
+    unitsFormatted = unitsFormatted.substring(0, unitsFormatted.length - 2)
+  }
+  // Truncate decimals
+  const decimalIndex = unitsFormatted.indexOf('.')
+  if (decimalIndex < 0) {
+    result = unitsFormatted
+  } else {
+    const leftOfDecimal = unitsFormatted.substring(0, decimalIndex)
+    const rightOfDecimal = unitsFormatted.substring(decimalIndex + 1)
+    if (rightOfDecimal.length > maxDecimals) {
+      result = leftOfDecimal + '.' + rightOfDecimal.substring(0, maxDecimals)
+    } else {
+      result = unitsFormatted
+    }
+  }
+  // Return "commified" result for human readability
+  return commify(result)
 }

--- a/vue-app/src/utils/amounts.ts
+++ b/vue-app/src/utils/amounts.ts
@@ -10,27 +10,10 @@ export function renderTokenAmount(
   maxDecimals: number,
   unitName: BigNumberish = 18
 ): string {
-  let result: string
-
   // Convert smaller units (really large integers) to whole AOE balance (human readable floats)
-  let unitsFormatted: string = formatUnits(amount, unitName).toString()
-  // Whole numbers return with single trailing zero decimal; remove this
-  if (unitsFormatted.substring(unitsFormatted.length - 2) === '.0') {
-    unitsFormatted = unitsFormatted.substring(0, unitsFormatted.length - 2)
-  }
-  // Truncate decimals
-  const decimalIndex = unitsFormatted.indexOf('.')
-  if (decimalIndex < 0) {
-    result = unitsFormatted
-  } else {
-    const leftOfDecimal = unitsFormatted.substring(0, decimalIndex)
-    const rightOfDecimal = unitsFormatted.substring(decimalIndex + 1)
-    if (rightOfDecimal.length > maxDecimals) {
-      result = leftOfDecimal + '.' + rightOfDecimal.substring(0, maxDecimals)
-    } else {
-      result = unitsFormatted
-    }
-  }
+  const unitsFormatted: string = formatUnits(amount, unitName).toString()
+  // Parse BigNumber into float, fix to maxDecimals, then parse again to remove any trailing zeros
+  const result = parseFloat(parseFloat(unitsFormatted).toFixed(maxDecimals))
   // Return "commified" result for human readability
   return commify(result)
 }

--- a/vue-app/src/utils/amounts.ts
+++ b/vue-app/src/utils/amounts.ts
@@ -11,9 +11,9 @@ export function renderTokenAmount(
   unitName: BigNumberish = 18
 ): string {
   // Convert smaller units (really large integers) to whole AOE balance (human readable floats)
-  const unitsFormatted: string = formatUnits(amount, unitName).toString()
-  // Parse BigNumber into float, fix to maxDecimals, then parse again to remove any trailing zeros
-  const result = parseFloat(parseFloat(unitsFormatted).toFixed(maxDecimals))
+  const formatted: string = formatUnits(amount, unitName).toString()
+  // Parse string into float, fix to maxDecimals, then parse again to remove any trailing zeros
+  const result = parseFloat(parseFloat(formatted).toFixed(maxDecimals))
   // Return "commified" result for human readability
   return commify(result)
 }


### PR DESCRIPTION
### Description
- Adds a helper function that takes in a `BigNumber` (ether or token balance) and desired number of decimal places to allow, and returns a "commified" version with decimals truncated appropriately.
- Implemented in WalletWidget to truncate decimal places of ETH/token balances.
- Chose **5** decimal places for both ETH and DAI as a starting point. For DAI balance, this keeps it consistent with what is allowed in the Cart, but could arguably be reduced even more given relatively low value of 1 DAI (ie. 2 decimal places)

### Screenshot
![image](https://user-images.githubusercontent.com/54227730/131439479-28436701-fbc5-41fe-806c-fdeddffcd9f7.png)

![image](https://user-images.githubusercontent.com/54227730/131439724-ec8c8f0f-ba98-4ca0-a69c-fcdb5f505ec1.png)

### Related issue
#327
