### PR TITLE
Hide address in mobile WalletWidget

### DIFF
--- a/vue-app/src/components/WalletWidget.vue
+++ b/vue-app/src/components/WalletWidget.vue
@@ -167,6 +167,9 @@ export default class WalletWidget extends Vue {
   .profile-name {
     font-size: 14px;
     opacity: 0.8;
+    @media (max-width: $breakpoint-s) {
+      display: none;
+    }
   }
 
   .balance {


### PR DESCRIPTION
- Hide `.profile-name` class on mobile (below `$breakpoint-s`)
- Prevents crowding of nav bar on mobile