### PR TITLE
Adjust `top` position of project CTA column to clear nav bar

### DIFF
--- a/vue-app/src/views/Project.vue
+++ b/vue-app/src/views/Project.vue
@@ -276,7 +276,7 @@ export default class ProjectView extends Vue {
 .sticky-column {
   grid-area: actions;
   position: sticky;
-  top: 2rem;
+  top: 6rem;
   display: flex;
   flex-direction: column;
   align-self: start;


### PR DESCRIPTION
Small patch for desktop version of Project page view, changed top sticky position to `6rem` from `2rem` giving more clearance on top for the CTA section (contribute/claim/links):

### Alignment after scrolling down page a bit:
![image](https://user-images.githubusercontent.com/54227730/131749026-f82aa799-e541-4b7c-86c1-0466634ccec0.png)
