### PR TITLE
Display tx receipt on /join/success page

### DIFF
--- a/vue-app/src/components/RecipientSubmissionWidget.vue
+++ b/vue-app/src/components/RecipientSubmissionWidget.vue
@@ -288,7 +288,7 @@ export default class RecipientSubmissionWidget extends Vue {
       this.$router.push({
         name: 'project-added',
         params: {
-          txHash: this.txHash,
+          hash: this.txHash,
         },
       })
     }

--- a/vue-app/src/router/index.ts
+++ b/vue-app/src/router/index.ts
@@ -151,7 +151,7 @@ const routes = [
     },
   },
   {
-    path: '/join/success',
+    path: '/join/success/:hash',
     name: 'project-added',
     component: ProjectAdded,
     meta: {

--- a/vue-app/src/views/ProjectAdded.vue
+++ b/vue-app/src/views/ProjectAdded.vue
@@ -9,7 +9,7 @@
           <span class="emoji">🎉</span>
           <div class="flex-title">
             <h1>Project submitted!</h1>
-            <transaction-receipt :hash="txHash" />
+            <transaction-receipt :hash="$route.params.hash" />
           </div>
           <div class="subtitle">You’re almost on board this funding round</div>
           <ul>
@@ -62,10 +62,8 @@ import { blockExplorer } from '@/api/core'
 })
 export default class ProjectAdded extends Vue {
   challengePeriodDuration: number | null = null
-  txHash = ''
 
   async created() {
-    this.txHash = this.$route.params.txHash
     this.challengePeriodDuration = this.registryInfo.challengePeriodDuration
   }
 
@@ -74,7 +72,7 @@ export default class ProjectAdded extends Vue {
   }
 
   get blockExplorerUrl(): string {
-    return `${blockExplorer}/tx/${this.txHash}`
+    return `${blockExplorer}/tx/${this.$route.params.txHash}`
   }
 
   formatDuration(seconds: number): string {


### PR DESCRIPTION
Fixes: https://github.com/ethereum/clrfund/issues/338

**What Changed**
- Mostly just making the route param more obvious. We were already following the pattern of using it, but now its in line with how we do it in other places.