### PR TITLE
Mobile - full-width button styles

### DIFF
--- a/vue-app/src/components/WalletWidget.vue
+++ b/vue-app/src/components/WalletWidget.vue
@@ -2,7 +2,11 @@
   <div :class="{ container: !isActionButton }">
     <button
       v-if="!currentUser"
-      :class="isActionButton ? 'btn-action' : 'app-btn'"
+      :class="{
+        'btn-action': isActionButton,
+        'app-btn': !isActionButton,
+        'full-width': fullWidth,
+      }"
       @click="showModal()"
     >
       Connect
@@ -55,6 +59,8 @@ export default class WalletWidget extends Vue {
   // Boolean to only show Connect button, styled like an action button,
   // which hides the widget that would otherwise display after connecting
   @Prop() isActionButton!: boolean
+  // Boolean to allow connect button to be full width
+  @Prop() fullWidth!: boolean
 
   toggleProfile(): void {
     this.showProfilePanel = !this.showProfilePanel
@@ -204,6 +210,8 @@ export default class WalletWidget extends Vue {
 }
 
 .full-width {
-  width: 100%;
+  @media (max-width: $breakpoint-m) {
+    width: 100%;
+  }
 }
 </style>

--- a/vue-app/src/components/WalletWidget.vue
+++ b/vue-app/src/components/WalletWidget.vue
@@ -5,7 +5,7 @@
       :class="{
         'btn-action': isActionButton,
         'app-btn': !isActionButton,
-        'full-width': fullWidth,
+        'full-width-mobile': fullWidthMobile,
       }"
       @click="showModal()"
     >
@@ -60,7 +60,7 @@ export default class WalletWidget extends Vue {
   // which hides the widget that would otherwise display after connecting
   @Prop() isActionButton!: boolean
   // Boolean to allow connect button to be full width
-  @Prop() fullWidth!: boolean
+  @Prop() fullWidthMobile!: boolean
 
   toggleProfile(): void {
     this.showProfilePanel = !this.showProfilePanel
@@ -209,7 +209,7 @@ export default class WalletWidget extends Vue {
   }
 }
 
-.full-width {
+.full-width-mobile {
   @media (max-width: $breakpoint-m) {
     width: 100%;
   }

--- a/vue-app/src/views/VerifyLanding.vue
+++ b/vue-app/src/views/VerifyLanding.vue
@@ -53,7 +53,11 @@
         still get BrightID verified to prepare for next time.
       </div>
       <div class="btn-container mt2">
-        <wallet-widget v-if="!currentUser" :isActionButton="true" />
+        <wallet-widget
+          v-if="!currentUser"
+          :isActionButton="true"
+          :fullWidth="true"
+        />
         <links v-if="currentUser" to="/verify/connect" class="btn-primary">
           I have BrightID installed
         </links>

--- a/vue-app/src/views/VerifyLanding.vue
+++ b/vue-app/src/views/VerifyLanding.vue
@@ -56,7 +56,7 @@
         <wallet-widget
           v-if="!currentUser"
           :isActionButton="true"
-          :fullWidth="true"
+          :fullWidthMobile="true"
         />
         <links v-if="currentUser" to="/verify/connect" class="btn-primary">
           I have BrightID installed


### PR DESCRIPTION
Fixes: https://github.com/ethereum/clrfund/issues/312

**What changed**
- Added prop to WalletWidget that allows for the option of the connect button being full width
- use this new prop in BrightID verify landing