### PR TITLE
BrightId - polling the profile endpoint and TypeError: Cannot read property 'isVerified' of undefined

### DIFF
--- a/vue-app/src/App.vue
+++ b/vue-app/src/App.vue
@@ -118,7 +118,6 @@ export default class App extends Vue {
     if (this.$store.state.currentRound) {
       // Load cart & contributor data for current round
       await this.$store.dispatch(LOAD_USER_INFO)
-      await this.$store.dispatch(LOAD_BRIGHT_ID)
       this.$store.dispatch(LOAD_CART)
       this.$store.dispatch(LOAD_COMMITTED_CART)
       this.$store.dispatch(LOAD_CONTRIBUTOR_DATA)

--- a/vue-app/src/components/WalletWidget.vue
+++ b/vue-app/src/components/WalletWidget.vue
@@ -114,7 +114,7 @@ export default class WalletWidget extends Vue {
     this.$modal.show(WalletModal, {}, { width: 400, top: 20 })
   }
 
-  @Watch('currentUser')
+  @Watch('$web3.user')
   async updateProfileImage(currentUser: User): Promise<void> {
     if (currentUser) {
       const url = await getProfileImageUrl(currentUser.walletAddress)

--- a/vue-app/src/store/index.ts
+++ b/vue-app/src/store/index.ts
@@ -445,11 +445,12 @@ const actions = {
       getContributorStorageKey(state.currentRound.fundingRoundAddress)
     )
   },
-  async [LOGIN_USER]({ state }) {
+  async [LOGIN_USER]({ state, dispatch }) {
     await loginUser(
       state.currentUser.walletAddress,
       state.currentUser.encryptionKey
     )
+    dispatch(LOAD_BRIGHT_ID)
   },
   [LOGOUT_USER]({ commit, dispatch }) {
     dispatch(UNWATCH_CART)


### PR DESCRIPTION
Fixes: https://github.com/ethereum/clrfund/issues/329
Fixes: https://github.com/ethereum/clrfund/issues/320

**What Changed**
- Poll for brightid info on user login
- Only look for user profile picture when user is connected, not every time currentUser has a change