### PR TITLE
BrightId - verify page displaying error while loading

### DIFF
--- a/vue-app/src/views/VerifyLanding.vue
+++ b/vue-app/src/views/VerifyLanding.vue
@@ -98,7 +98,7 @@ export default class VerifyLanding extends Vue {
   get isRoundFullOrOver(): boolean {
     const currentRound = this.$store.state.currentRound
     if (!currentRound) {
-      return true
+      return false
     }
     const hasHitMaxContributors =
       currentRound.maxContributors <= currentRound.contributors


### PR DESCRIPTION
Fixes: https://github.com/ethereum/clrfund/issues/323

**What Changed**
- return false in isRoundFullOrOver in VerifyLanding when currentRound is undefined. If it is undefined, and it doesnt fit the error message of the round being being over and no longer accepting donations.