### PR TITLE
Todo cleanup

### DIFF
--- a/vue-app/src/components/Accordion.vue
+++ b/vue-app/src/components/Accordion.vue
@@ -83,14 +83,10 @@ export default class Accordion extends Vue {
 }
 
 .tag {
-  /* background: #fff9; */
-  border-radius: 2rem;
-  font-family: 'Glacial Indifference', sans-serif;
   padding: 0.25rem 0.5rem;
+  border-radius: 2rem;
   padding-left: 0;
-  /* color: $bg-primary-color; */
   font-size: 16px;
   text-transform: uppercase;
-  width: fit-content;
 }
 </style>

--- a/vue-app/src/components/Cart.vue
+++ b/vue-app/src/components/Cart.vue
@@ -297,7 +297,6 @@
 import Vue from 'vue'
 import Component from 'vue-class-component'
 import { BigNumber, FixedNumber } from 'ethers'
-import { Network } from '@ethersproject/networks'
 import { parseFixed } from '@ethersproject/bignumber'
 import { commify, formatUnits } from '@ethersproject/units'
 import { DateTime } from 'luxon'
@@ -325,7 +324,6 @@ import {
   TOGGLE_SHOW_CART_PANEL,
 } from '@/store/mutation-types'
 import { formatAmount } from '@/utils/amounts'
-import { formatDateFromNow, getTimeLeft } from '@/utils/dates'
 import { CHAIN_INFO } from '@/plugins/Web3/constants/chains'
 
 @Component({

--- a/vue-app/src/components/FormProgressWidget.vue
+++ b/vue-app/src/components/FormProgressWidget.vue
@@ -63,7 +63,6 @@ import ProgressBar from '@/components/ProgressBar.vue'
 import FormNavigation from '@/components/FormNavigation.vue'
 import Links from '@/components/Links.vue'
 
-// TODO make `furthestStep` logic optional (not used in BrightID flow)
 @Component({
   components: {
     FormNavigation,

--- a/vue-app/src/components/ProjectListItem.vue
+++ b/vue-app/src/components/ProjectListItem.vue
@@ -226,17 +226,9 @@ export default class ProjectListItem extends Vue {
 }
 
 .tag {
-  padding: 0.5rem 0.75rem;
-  background: $bg-light-color;
-  box-shadow: $box-shadow;
-  color: $button-disabled-text-color;
-  font-family: 'Glacial Indifference', sans-serif;
-  width: fit-content;
-  border-radius: 4px;
   position: absolute;
   top: 0.5rem;
   right: 0.5rem;
+  box-shadow: $box-shadow;
 }
-
-//TODO: make tag component?
 </style>

--- a/vue-app/src/components/ProjectProfile.vue
+++ b/vue-app/src/components/ProjectProfile.vue
@@ -331,15 +331,6 @@ export default class ProjectProfile extends Vue {
         margin-bottom: 2rem;
       }
 
-      .tag {
-        padding: 0.5rem 0.75rem;
-        background: $bg-light-color;
-        color: $button-disabled-text-color;
-        font-family: 'Glacial Indifference', sans-serif;
-        width: fit-content;
-        border-radius: 0.25rem;
-      }
-
       .team-byline {
         line-height: 150%;
       }

--- a/vue-app/src/components/ProjectProfile.vue
+++ b/vue-app/src/components/ProjectProfile.vue
@@ -490,18 +490,6 @@ export default class ProjectProfile extends Vue {
     z-index: 1;
   }
 
-  .input-button {
-    background: #f7f7f7;
-    border-radius: 2rem;
-    border: 2px solid $bg-primary-color;
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    color: black;
-    padding: 0.125rem;
-    z-index: 100;
-  }
-
   .input {
     background: none;
     border: none;

--- a/vue-app/src/components/RecipientSubmissionWidget.vue
+++ b/vue-app/src/components/RecipientSubmissionWidget.vue
@@ -32,9 +32,8 @@
         <div v-if="isTxRejected" class="warning-text">
           You rejected the transaction in your wallet
         </div>
-        <!-- TODO update -->
         <div v-if="isWrongNetwork" class="warning-text">
-          We're on Optimism Network.<br />
+          We're on {{ chainLabel }}.<br />
           Switch over to the right network in your wallet.
         </div>
         <div v-if="isPending">
@@ -120,6 +119,7 @@ import WalletWidget from '@/components/WalletWidget.vue'
 import { formatAmount } from '@/utils/amounts'
 import { waitForTransaction } from '@/utils/contracts'
 import { RESET_RECIPIENT_DATA } from '@/store/mutation-types'
+import { CHAIN_INFO } from '@/plugins/Web3/constants/chains'
 
 @Component({
   components: {
@@ -208,6 +208,11 @@ export default class RecipientSubmissionWidget extends Vue {
       ).toFixed(2)
     }
     return '-'
+  }
+
+  get chainLabel(): string {
+    const chain = CHAIN_INFO[Number(process.env.VUE_APP_ETHEREUM_API_CHAINID)]
+    return chain.label
   }
 
   // TODO: Once either EIP-1559 or Arbitrum stuff is sorted, come back and finish gas estimate

--- a/vue-app/src/styles/_theme.scss
+++ b/vue-app/src/styles/_theme.scss
@@ -125,6 +125,15 @@
   }
 }
 
+.tag {
+  font-family: 'Glacial Indifference', sans-serif;
+  padding: 0.5rem 0.75rem;
+  background: $bg-light-color;
+  color: $button-disabled-text-color;
+  width: fit-content;
+  border-radius: 4px;
+}
+
 .token-icon {
   margin-left: 0.5rem;
 }

--- a/vue-app/src/utils/dates.ts
+++ b/vue-app/src/utils/dates.ts
@@ -1,5 +1,4 @@
 import { DateTime } from 'luxon'
-import * as humanizeDuration from 'humanize-duration'
 import { TimeLeft } from '@/api/round'
 
 export function formatDate(date: DateTime): string {
@@ -32,17 +31,4 @@ export function getTimeLeft(date: DateTime): TimeLeft {
     .split(' ')
     .map(Number)
   return { days, hours, minutes, seconds }
-}
-
-// TODO handle dates in the past (difference < 0, returns '0 seconds')
-export function formatDateFromNow(date: DateTime): string {
-  if (!date) {
-    return '...' //  TODO best place to do this?
-  }
-  const difference = getMillisecondsFromNow(date)
-  return humanizeDuration(difference, {
-    largest: 1,
-    units: ['mo', 'w', 'd', 'h', 'm', 's'],
-    round: true,
-  })
 }

--- a/vue-app/src/views/Project.vue
+++ b/vue-app/src/views/Project.vue
@@ -390,18 +390,6 @@ export default class ProjectView extends Vue {
   width: 100%;
 }
 
-.input-button {
-  background: #f7f7f7;
-  border-radius: 2rem;
-  border: 2px solid $bg-primary-color;
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  color: black;
-  padding: 0.125rem;
-  z-index: 100;
-}
-
 .donate-btn {
   padding: 0.5rem 1rem;
   background: $bg-primary-color;
@@ -427,18 +415,6 @@ export default class ProjectView extends Vue {
   text-align: center;
   box-shadow: 0px 4px 4px 0px 0, 0, 0, 0.25;
   z-index: 1;
-}
-
-.input-button {
-  background: #f7f7f7;
-  border-radius: 2rem;
-  border: 2px solid $bg-primary-color;
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  color: black;
-  padding: 0.125rem;
-  z-index: 100;
 }
 
 .input {

--- a/vue-app/src/views/Project.vue
+++ b/vue-app/src/views/Project.vue
@@ -375,15 +375,6 @@ export default class ProjectView extends Vue {
   }
 }
 
-.tag {
-  padding: 0.5rem 0.75rem;
-  background: $bg-light-color;
-  color: $button-disabled-text-color;
-  font-family: 'Glacial Indifference', sans-serif;
-  width: fit-content;
-  border-radius: 4px;
-}
-
 .contribute-btn,
 .in-cart,
 .claim-btn {


### PR DESCRIPTION
https://www.notion.so/efdn/TODOs-Cleanup-9353e3c12f144fe7801ce5e2d3950d9d

A start at handling a few of the low-hanging TODO's accumulating in the codebase. This does not cover all of them. Many TODO's have been broken off as their own actions (linked to within above doc), a few others could use a brief discussion as to how to handle.

- Removes some unused/redundant classes in `Project` and `ProjectProfile`
- Removes `furthestStep` todo, as the `FormProgressWidget` is no longer utilized by the BrightId verification flow
- Extracts overlapping `.tag` properties into shared class to limit redundancy throughout codebase
- Uses our dynamic chain label for `RecipientSubmissionWidget` instead of hardcoding L2 name.
- Removes `formatDateFromNow` as its usage has been replaced with `TimeLeft` component.