### PR TITLE
BrightId manual verification

### DIFF
--- a/vue-app/src/views/Verify.vue
+++ b/vue-app/src/views/Verify.vue
@@ -191,8 +191,8 @@
             <h2 class="step-title">Register</h2>
             <p>
               To protect the round from bribery and fraud, you need to add your
-              wallet address to a smart contract registry. Once you’re done,
-              you can join the funding round!
+              wallet address to a smart contract registry. Once you’re done, you
+              can join the funding round!
             </p>
             <div class="transaction">
               <button
@@ -227,8 +227,8 @@ import {
   selfSponsor,
   registerUser,
   BrightId,
-  getVerification,
   BrightIdError,
+  getBrightId,
 } from '@/api/bright-id'
 import { User } from '@/api/user'
 import Transaction from '@/components/Transaction.vue'
@@ -374,17 +374,14 @@ export default class VerifyView extends Vue {
     this.loadingManualVerify = true
 
     try {
-      const verification = await getVerification(this.currentUser.walletAddress)
+      const brightId = await getBrightId(this.currentUser.walletAddress)
 
-      if (verification.unique) {
+      if (brightId.isVerified) {
         this.isManuallyVerified = true
         setTimeout(() => {
           this.$store.commit(SET_CURRENT_USER, {
             ...this.currentUser,
-            brightId: {
-              ...this.currentUser.brightId,
-              isVerified: true,
-            },
+            brightId,
           })
         }, 5000)
       }


### PR DESCRIPTION
**Issue:**
1. Reach step 3 of the verification process (Get Verified)
2. Click on "Check if you are verified" when you get verified
3. In the next step (Get registered), click on "Become a contributor"
4. Nothing happens

We were using `getVerification` to do the manual verification (when the user clicks on "Check if you are verified"). The problem is that we were not storing the `verification` object in the store, so in the next step, there was no `verification` to send to the register.

**Solution:**
In this PR, we are using the `getBrightId` function that does all this logic for us and we store the complete `brightId` object in the same way we are doing in the `store/index` file.