### PR TITLE
Use correct arbitrum-rinkeby network name

### DIFF
--- a/subgraph/config/arbitrum-rinkeby.json
+++ b/subgraph/config/arbitrum-rinkeby.json
@@ -1,0 +1,6 @@
+{
+  "network": "arbitrum-rinkeby",
+  "address": "0xC032e80a413Be959d9a9B6e5CadE53c870074d37",
+  "factoryStartBlock": 4806990,
+  "recipientRegistryStartBlock": 4806990
+}

--- a/subgraph/config/arbitrum.json
+++ b/subgraph/config/arbitrum.json
@@ -1,6 +1,0 @@
-{
-  "network": "arbitrum",
-  "address": "0xD6443BE8536809D02c2cA91b9db4112156cEA27c",
-  "factoryStartBlock": 4711510,
-  "recipientRegistryStartBlock": 4711510
-}

--- a/subgraph/package.json
+++ b/subgraph/package.json
@@ -15,7 +15,7 @@
   "private": true,
   "scripts": {
     "prepare:hardhat": "mustache config/hardhat.json subgraph.template.yaml > subgraph.yaml",
-    "prepare:arbitrum": "mustache config/arbitrum.json subgraph.template.yaml > subgraph.yaml",
+    "prepare:arbitrum-rinkeby": "mustache config/arbitrum-rinkeby.json subgraph.template.yaml > subgraph.yaml",
     "prepare:xdai": "mustache config/xdai.json subgraph.template.yaml > subgraph.yaml",
     "codegen": "graph codegen",
     "lint:js": "eslint 'src/*.ts'",


### PR DESCRIPTION
`arbitrum` does not exists in the supported network list. It is `arbitrum-one` or `arbitrum-rinkeby`. Using the latter right now.

You can check the complete list here https://thegraph.com/docs/legacyexplorer/whatislegacyexplorer#supported-networks-on-the-legacy-explorer or 