### PR TITLE
Style all /about content

### DIFF
--- a/vue-app/src/styles/_theme.scss
+++ b/vue-app/src/styles/_theme.scss
@@ -149,3 +149,29 @@
 .mt2 {
   margin-top: 2rem;
 }
+
+.about {
+  padding-bottom: 4rem;
+
+  .content-heading {
+    border-bottom: $border;
+  }
+
+  h2 {
+    font-family: 'Glacial Indifference', sans-serif;
+    font-weight: bold;
+    font-size: 32px;
+    letter-spacing: -0.015em;
+  }
+
+  p {
+    font-size: 16px;
+    line-height: 150%;
+  }
+
+  li {
+    font-size: 16px;
+    line-height: 150%;
+    margin-bottom: 15px;
+  }
+}

--- a/vue-app/src/views/About.vue
+++ b/vue-app/src/views/About.vue
@@ -128,9 +128,3 @@ import Links from '@/components/Links.vue'
 @Component({ components: { Links } })
 export default class About extends Vue {}
 </script>
-
-<style scoped lang="scss">
-/* TODO apply these styles across all About subpages  */
-@import '../styles/vars';
-@import '../styles/theme';
-</style>

--- a/vue-app/src/views/About.vue
+++ b/vue-app/src/views/About.vue
@@ -132,25 +132,5 @@ export default class About extends Vue {}
 <style scoped lang="scss">
 /* TODO apply these styles across all About subpages  */
 @import '../styles/vars';
-
-.content-heading {
-  border-bottom: $border;
-}
-
-h2 {
-  font-family: 'Glacial Indifference', sans-serif;
-  font-weight: bold;
-  font-size: 32px;
-  letter-spacing: -0.015em;
-}
-
-p {
-  font-size: 16px;
-  line-height: 30px;
-}
-
-li {
-  font-size: 16px;
-  line-height: 150%;
-}
+@import '../styles/theme';
 </style>

--- a/vue-app/src/views/AboutContributors.vue
+++ b/vue-app/src/views/AboutContributors.vue
@@ -99,8 +99,3 @@ export default class AboutContributors extends Vue {
   }
 }
 </script>
-
-<style scoped lang="scss">
-@import '../styles/vars';
-@import '../styles/theme';
-</style>

--- a/vue-app/src/views/AboutContributors.vue
+++ b/vue-app/src/views/AboutContributors.vue
@@ -102,29 +102,5 @@ export default class AboutContributors extends Vue {
 
 <style scoped lang="scss">
 @import '../styles/vars';
-
-.about {
-  padding-bottom: 4rem;
-}
-
-.content-heading {
-  border-bottom: $border;
-}
-
-h2 {
-  font-family: 'Glacial Indifference', sans-serif;
-  font-weight: bold;
-  font-size: 32px;
-  letter-spacing: -0.015em;
-}
-
-p {
-  font-size: 16px;
-  line-height: 150%;
-}
-
-li {
-  font-size: 16px;
-  line-height: 150%;
-}
+@import '../styles/theme';
 </style>

--- a/vue-app/src/views/AboutDecentralization.vue
+++ b/vue-app/src/views/AboutDecentralization.vue
@@ -37,8 +37,8 @@
     </ul>
     <p>
       Each of these pieces exists in an Ethereum smart contract (see the code
-      <links to="https://github.com/clrfund/monorepo">here</links>), meaning its functionality is maintained by Ethereum miners, a
-      decentralized group.
+      <links to="https://github.com/clrfund/monorepo">here</links>), meaning its
+      functionality is maintained by Ethereum miners, a decentralized group.
     </p>
     <h2>Why is clr.fund decentralized?</h2>
     <p>
@@ -83,29 +83,5 @@ export default class AboutDecentralization extends Vue {}
 
 <style scoped lang="scss">
 @import '../styles/vars';
-
-.about {
-  padding-bottom: 4rem;
-}
-
-.content-heading {
-  border-bottom: $border;
-}
-
-h2 {
-  font-family: 'Glacial Indifference', sans-serif;
-  font-weight: bold;
-  font-size: 32px;
-  letter-spacing: -0.015em;
-}
-
-p {
-  font-size: 16px;
-  line-height: 150%;
-}
-
-li {
-  font-size: 16px;
-  line-height: 150%;
-}
+@import '../styles/theme';
 </style>

--- a/vue-app/src/views/AboutDecentralization.vue
+++ b/vue-app/src/views/AboutDecentralization.vue
@@ -80,8 +80,3 @@ import Links from '@/components/Links.vue'
 @Component({ components: { Links } })
 export default class AboutDecentralization extends Vue {}
 </script>
-
-<style scoped lang="scss">
-@import '../styles/vars';
-@import '../styles/theme';
-</style>

--- a/vue-app/src/views/AboutHowItWorks.vue
+++ b/vue-app/src/views/AboutHowItWorks.vue
@@ -150,8 +150,3 @@ import Links from '@/components/Links.vue'
 @Component({ components: { Links } })
 export default class AboutHowItWorks extends Vue {}
 </script>
-
-<style scoped lang="scss">
-@import '../styles/vars';
-@import '../styles/theme';
-</style>

--- a/vue-app/src/views/AboutHowItWorks.vue
+++ b/vue-app/src/views/AboutHowItWorks.vue
@@ -153,29 +153,5 @@ export default class AboutHowItWorks extends Vue {}
 
 <style scoped lang="scss">
 @import '../styles/vars';
-
-.about {
-  padding-bottom: 4rem;
-}
-
-.content-heading {
-  border-bottom: $border;
-}
-
-h2 {
-  font-family: 'Glacial Indifference', sans-serif;
-  font-weight: bold;
-  font-size: 32px;
-  letter-spacing: -0.015em;
-}
-
-p {
-  font-size: 16px;
-  line-height: 150%;
-}
-
-li {
-  font-size: 16px;
-  line-height: 150%;
-}
+@import '../styles/theme';
 </style>

--- a/vue-app/src/views/AboutLayer2.vue
+++ b/vue-app/src/views/AboutLayer2.vue
@@ -87,8 +87,3 @@ import Links from '@/components/Links.vue'
 @Component({ components: { Links } })
 export default class AboutLayer2 extends Vue {}
 </script>
-
-<style scoped lang="scss">
-@import '../styles/vars';
-@import '../styles/theme';
-</style>

--- a/vue-app/src/views/AboutLayer2.vue
+++ b/vue-app/src/views/AboutLayer2.vue
@@ -90,29 +90,5 @@ export default class AboutLayer2 extends Vue {}
 
 <style scoped lang="scss">
 @import '../styles/vars';
-
-.about {
-  padding-bottom: 4rem;
-}
-
-.content-heading {
-  border-bottom: $border;
-}
-
-h2 {
-  font-family: 'Glacial Indifference', sans-serif;
-  font-weight: bold;
-  font-size: 32px;
-  letter-spacing: -0.015em;
-}
-
-p {
-  font-size: 16px;
-  line-height: 150%;
-}
-
-li {
-  font-size: 16px;
-  line-height: 150%;
-}
+@import '../styles/theme';
 </style>

--- a/vue-app/src/views/AboutMaci.vue
+++ b/vue-app/src/views/AboutMaci.vue
@@ -240,8 +240,3 @@ import Links from '@/components/Links.vue'
 @Component({ components: { Links } })
 export default class AboutMaci extends Vue {}
 </script>
-
-<style scoped lang="scss">
-@import '../styles/vars';
-@import '../styles/theme';
-</style>

--- a/vue-app/src/views/AboutMaci.vue
+++ b/vue-app/src/views/AboutMaci.vue
@@ -192,9 +192,9 @@
         know that it's for the integrity of the round.
       </li>
       <li>
-        You can only contribute once per round. Once you have
-        contributed, you can add/remove projects and reallocate your funds but
-        you can't increase your total contribution amount.
+        You can only contribute once per round. Once you have contributed, you
+        can add/remove projects and reallocate your funds but you can't increase
+        your total contribution amount.
       </li>
     </ul>
     <h2>More</h2>
@@ -243,29 +243,5 @@ export default class AboutMaci extends Vue {}
 
 <style scoped lang="scss">
 @import '../styles/vars';
-
-.about {
-  padding-bottom: 4rem;
-}
-
-.content-heading {
-  border-bottom: $border;
-}
-
-h2 {
-  font-family: 'Glacial Indifference', sans-serif;
-  font-weight: bold;
-  font-size: 32px;
-  letter-spacing: -0.015em;
-}
-
-p {
-  font-size: 16px;
-  line-height: 150%;
-}
-
-li {
-  font-size: 16px;
-  line-height: 150%;
-}
+@import '../styles/theme';
 </style>

--- a/vue-app/src/views/AboutPublicGoods.vue
+++ b/vue-app/src/views/AboutPublicGoods.vue
@@ -64,8 +64,3 @@ import Links from '@/components/Links.vue'
 @Component({ components: { Links } })
 export default class AboutPublicGoods extends Vue {}
 </script>
-
-<style scoped lang="scss">
-@import '../styles/vars';
-@import '../styles/theme';
-</style>

--- a/vue-app/src/views/AboutPublicGoods.vue
+++ b/vue-app/src/views/AboutPublicGoods.vue
@@ -67,29 +67,5 @@ export default class AboutPublicGoods extends Vue {}
 
 <style scoped lang="scss">
 @import '../styles/vars';
-
-.about {
-  padding-bottom: 4rem;
-}
-
-.content-heading {
-  border-bottom: $border;
-}
-
-h2 {
-  font-family: 'Glacial Indifference', sans-serif;
-  font-weight: bold;
-  font-size: 32px;
-  letter-spacing: -0.015em;
-}
-
-p {
-  font-size: 16px;
-  line-height: 150%;
-}
-
-li {
-  font-size: 16px;
-  line-height: 150%;
-}
+@import '../styles/theme';
 </style>

--- a/vue-app/src/views/AboutQuadraticFunding.vue
+++ b/vue-app/src/views/AboutQuadraticFunding.vue
@@ -157,29 +157,5 @@ export default class AboutQuadraticFunding extends Vue {}
 
 <style scoped lang="scss">
 @import '../styles/vars';
-
-.about {
-  padding-bottom: 4rem;
-}
-
-.content-heading {
-  border-bottom: $border;
-}
-
-h2 {
-  font-family: 'Glacial Indifference', sans-serif;
-  font-weight: bold;
-  font-size: 32px;
-  letter-spacing: -0.015em;
-}
-
-p {
-  font-size: 16px;
-  line-height: 150%;
-}
-
-li {
-  font-size: 16px;
-  line-height: 150%;
-}
+@import '../styles/theme';
 </style>

--- a/vue-app/src/views/AboutQuadraticFunding.vue
+++ b/vue-app/src/views/AboutQuadraticFunding.vue
@@ -154,8 +154,3 @@ import Links from '@/components/Links.vue'
 @Component({ components: { Links } })
 export default class AboutQuadraticFunding extends Vue {}
 </script>
-
-<style scoped lang="scss">
-@import '../styles/vars';
-@import '../styles/theme';
-</style>

--- a/vue-app/src/views/AboutRecipients.vue
+++ b/vue-app/src/views/AboutRecipients.vue
@@ -62,8 +62,3 @@ import Links from '@/components/Links.vue'
 @Component({ components: { Links } })
 export default class AboutRecipients extends Vue {}
 </script>
-
-<style scoped lang="scss">
-@import '../styles/vars';
-@import '../styles/theme';
-</style>

--- a/vue-app/src/views/AboutRecipients.vue
+++ b/vue-app/src/views/AboutRecipients.vue
@@ -65,29 +65,5 @@ export default class AboutRecipients extends Vue {}
 
 <style scoped lang="scss">
 @import '../styles/vars';
-
-.about {
-  padding-bottom: 4rem;
-}
-
-.content-heading {
-  border-bottom: $border;
-}
-
-h2 {
-  font-family: 'Glacial Indifference', sans-serif;
-  font-weight: bold;
-  font-size: 32px;
-  letter-spacing: -0.015em;
-}
-
-p {
-  font-size: 16px;
-  line-height: 150%;
-}
-
-li {
-  font-size: 16px;
-  line-height: 150%;
-}
+@import '../styles/theme';
 </style>

--- a/vue-app/src/views/AboutSybilResistance.vue
+++ b/vue-app/src/views/AboutSybilResistance.vue
@@ -105,25 +105,5 @@ export default class AboutSybilResistance extends Vue {}
 
 <style scoped lang="scss">
 @import '../styles/vars';
-
-.content-heading {
-  border-bottom: $border;
-}
-
-h2 {
-  font-family: 'Glacial Indifference', sans-serif;
-  font-weight: bold;
-  font-size: 32px;
-  letter-spacing: -0.015em;
-}
-
-p {
-  font-size: 16px;
-  line-height: 30px;
-}
-
-li {
-  font-size: 16px;
-  line-height: 150%;
-}
+@import '../styles/theme';
 </style>

--- a/vue-app/src/views/AboutSybilResistance.vue
+++ b/vue-app/src/views/AboutSybilResistance.vue
@@ -102,8 +102,3 @@ import Links from '@/components/Links.vue'
 @Component({ components: { Links } })
 export default class AboutSybilResistance extends Vue {}
 </script>
-
-<style scoped lang="scss">
-@import '../styles/vars';
-@import '../styles/theme';
-</style>


### PR DESCRIPTION
Fixes: https://github.com/ethereum/clrfund/issues/395

**What Changed**
- Moved about styles into _themes.scss
- Import themes file into /about pages
- Some styling around li

Note: Open to feedback on li styling. Tried to give some more breathing room to make them easier to read.