### PR TITLE
Contribution success backdrop cutoff

### DIFF
--- a/vue-app/src/views/TransactionSuccess.vue
+++ b/vue-app/src/views/TransactionSuccess.vue
@@ -134,7 +134,7 @@ export default class TransactionSuccess extends Vue {
 .dropshadow {
   position: relative;
   background: linear-gradient(
-    171.34deg,
+    175deg,
     rgba(0, 0, 0, 0.4) 56.5%,
     rgba(196, 196, 196, 0) 75.75%
   );

--- a/vue-app/src/views/TransactionSuccess.vue
+++ b/vue-app/src/views/TransactionSuccess.vue
@@ -134,10 +134,11 @@ export default class TransactionSuccess extends Vue {
 .dropshadow {
   position: relative;
   background: linear-gradient(
-    175deg,
+    180deg,
     rgba(0, 0, 0, 0.4) 56.5%,
     rgba(196, 196, 196, 0) 75.75%
   );
+  height: 80vh;
 }
 
 .content {


### PR DESCRIPTION
Fixes: https://github.com/ethereum/clrfund/issues/359

**What Changed**
- Change angle for linear gradient to prevent cutoff
- Make dropshadow div have some height to allow for the gradient to have more room to blur