### PR TITLE
Fix recipients query to work in join phase

### DIFF
--- a/vue-app/src/api/recipient-registry-optimistic.ts
+++ b/vue-app/src/api/recipient-registry-optimistic.ts
@@ -142,18 +142,15 @@ export interface Request {
 }
 
 export async function getRequests(
-  registryAddress: string,
   registryInfo: RegistryInfo
 ): Promise<Request[]> {
-  const data = await sdk.GetRecipients({
-    registryAddress: registryAddress.toLowerCase(),
-  })
+  const data = await sdk.GetRecipients()
 
-  if (!data.recipientRegistry?.recipients?.length) {
+  if (!data.recipients?.length) {
     return []
   }
 
-  const recipients = data.recipientRegistry?.recipients
+  const recipients = data.recipients
 
   const requests: Record<string, Request> = {}
   for (const recipient of recipients) {
@@ -342,15 +339,13 @@ export async function getProjects(
   startTime?: number,
   endTime?: number
 ): Promise<Project[]> {
-  const data = await sdk.GetRecipients({
-    registryAddress: registryAddress.toLowerCase(),
-  })
+  const data = await sdk.GetRecipients()
 
-  if (!data.recipientRegistry?.recipients?.length) {
+  if (!data.recipients?.length) {
     return []
   }
 
-  const recipients = data.recipientRegistry?.recipients
+  const recipients = data.recipients
 
   const registry = new Contract(
     registryAddress,

--- a/vue-app/src/graphql/API.ts
+++ b/vue-app/src/graphql/API.ts
@@ -514,6 +514,8 @@ export type FundingRound = {
   __typename?: 'FundingRound';
   id: Scalars['ID'];
   fundingRoundFactory: Maybe<FundingRoundFactory>;
+  maci: Maybe<Scalars['Bytes']>;
+  messages: Maybe<Array<Message>>;
   recipientRegistry: Maybe<RecipientRegistry>;
   recipientRegistryAddress: Maybe<Scalars['Bytes']>;
   contributorRegistry: Maybe<ContributorRegistry>;
@@ -523,7 +525,6 @@ export type FundingRound = {
   signUpDeadline: Maybe<Scalars['BigInt']>;
   votingDeadline: Maybe<Scalars['BigInt']>;
   coordinator: Maybe<Scalars['Bytes']>;
-  maci: Maybe<Scalars['Bytes']>;
   voiceCreditFactor: Maybe<Scalars['BigInt']>;
   contributorCount: Scalars['BigInt'];
   recipientCount: Scalars['BigInt'];
@@ -539,6 +540,15 @@ export type FundingRound = {
   votes: Maybe<Array<Vote>>;
   createdAt: Maybe<Scalars['String']>;
   lastUpdatedAt: Maybe<Scalars['String']>;
+};
+
+
+export type FundingRoundMessagesArgs = {
+  skip?: Maybe<Scalars['Int']>;
+  first?: Maybe<Scalars['Int']>;
+  orderBy: Maybe<Message_OrderBy>;
+  orderDirection: Maybe<OrderDirection>;
+  where: Maybe<Message_Filter>;
 };
 
 
@@ -891,6 +901,12 @@ export type FundingRound_Filter = {
   fundingRoundFactory_not_starts_with: Maybe<Scalars['String']>;
   fundingRoundFactory_ends_with: Maybe<Scalars['String']>;
   fundingRoundFactory_not_ends_with: Maybe<Scalars['String']>;
+  maci: Maybe<Scalars['Bytes']>;
+  maci_not: Maybe<Scalars['Bytes']>;
+  maci_in: Maybe<Array<Scalars['Bytes']>>;
+  maci_not_in: Maybe<Array<Scalars['Bytes']>>;
+  maci_contains: Maybe<Scalars['Bytes']>;
+  maci_not_contains: Maybe<Scalars['Bytes']>;
   recipientRegistry: Maybe<Scalars['String']>;
   recipientRegistry_not: Maybe<Scalars['String']>;
   recipientRegistry_gt: Maybe<Scalars['String']>;
@@ -967,12 +983,6 @@ export type FundingRound_Filter = {
   coordinator_not_in: Maybe<Array<Scalars['Bytes']>>;
   coordinator_contains: Maybe<Scalars['Bytes']>;
   coordinator_not_contains: Maybe<Scalars['Bytes']>;
-  maci: Maybe<Scalars['Bytes']>;
-  maci_not: Maybe<Scalars['Bytes']>;
-  maci_in: Maybe<Array<Scalars['Bytes']>>;
-  maci_not_in: Maybe<Array<Scalars['Bytes']>>;
-  maci_contains: Maybe<Scalars['Bytes']>;
-  maci_not_contains: Maybe<Scalars['Bytes']>;
   voiceCreditFactor: Maybe<Scalars['BigInt']>;
   voiceCreditFactor_not: Maybe<Scalars['BigInt']>;
   voiceCreditFactor_gt: Maybe<Scalars['BigInt']>;
@@ -1076,6 +1086,8 @@ export type FundingRound_Filter = {
 export enum FundingRound_OrderBy {
   Id = 'id',
   FundingRoundFactory = 'fundingRoundFactory',
+  Maci = 'maci',
+  Messages = 'messages',
   RecipientRegistry = 'recipientRegistry',
   RecipientRegistryAddress = 'recipientRegistryAddress',
   ContributorRegistry = 'contributorRegistry',
@@ -1085,7 +1097,6 @@ export enum FundingRound_OrderBy {
   SignUpDeadline = 'signUpDeadline',
   VotingDeadline = 'votingDeadline',
   Coordinator = 'coordinator',
-  Maci = 'maci',
   VoiceCreditFactor = 'voiceCreditFactor',
   ContributorCount = 'contributorCount',
   RecipientCount = 'recipientCount',
@@ -1103,15 +1114,190 @@ export enum FundingRound_OrderBy {
   LastUpdatedAt = 'lastUpdatedAt'
 }
 
+export type Message = {
+  __typename?: 'Message';
+  id: Scalars['ID'];
+  data: Maybe<Array<Scalars['BigInt']>>;
+  iv: Scalars['BigInt'];
+  publicKey: Maybe<PublicKey>;
+  fundingRound: Maybe<FundingRound>;
+  timestamp: Maybe<Scalars['String']>;
+};
+
+export type Message_Filter = {
+  id: Maybe<Scalars['ID']>;
+  id_not: Maybe<Scalars['ID']>;
+  id_gt: Maybe<Scalars['ID']>;
+  id_lt: Maybe<Scalars['ID']>;
+  id_gte: Maybe<Scalars['ID']>;
+  id_lte: Maybe<Scalars['ID']>;
+  id_in: Maybe<Array<Scalars['ID']>>;
+  id_not_in: Maybe<Array<Scalars['ID']>>;
+  data: Maybe<Array<Scalars['BigInt']>>;
+  data_not: Maybe<Array<Scalars['BigInt']>>;
+  data_contains: Maybe<Array<Scalars['BigInt']>>;
+  data_not_contains: Maybe<Array<Scalars['BigInt']>>;
+  iv: Maybe<Scalars['BigInt']>;
+  iv_not: Maybe<Scalars['BigInt']>;
+  iv_gt: Maybe<Scalars['BigInt']>;
+  iv_lt: Maybe<Scalars['BigInt']>;
+  iv_gte: Maybe<Scalars['BigInt']>;
+  iv_lte: Maybe<Scalars['BigInt']>;
+  iv_in: Maybe<Array<Scalars['BigInt']>>;
+  iv_not_in: Maybe<Array<Scalars['BigInt']>>;
+  publicKey: Maybe<Scalars['String']>;
+  publicKey_not: Maybe<Scalars['String']>;
+  publicKey_gt: Maybe<Scalars['String']>;
+  publicKey_lt: Maybe<Scalars['String']>;
+  publicKey_gte: Maybe<Scalars['String']>;
+  publicKey_lte: Maybe<Scalars['String']>;
+  publicKey_in: Maybe<Array<Scalars['String']>>;
+  publicKey_not_in: Maybe<Array<Scalars['String']>>;
+  publicKey_contains: Maybe<Scalars['String']>;
+  publicKey_not_contains: Maybe<Scalars['String']>;
+  publicKey_starts_with: Maybe<Scalars['String']>;
+  publicKey_not_starts_with: Maybe<Scalars['String']>;
+  publicKey_ends_with: Maybe<Scalars['String']>;
+  publicKey_not_ends_with: Maybe<Scalars['String']>;
+  fundingRound: Maybe<Scalars['String']>;
+  fundingRound_not: Maybe<Scalars['String']>;
+  fundingRound_gt: Maybe<Scalars['String']>;
+  fundingRound_lt: Maybe<Scalars['String']>;
+  fundingRound_gte: Maybe<Scalars['String']>;
+  fundingRound_lte: Maybe<Scalars['String']>;
+  fundingRound_in: Maybe<Array<Scalars['String']>>;
+  fundingRound_not_in: Maybe<Array<Scalars['String']>>;
+  fundingRound_contains: Maybe<Scalars['String']>;
+  fundingRound_not_contains: Maybe<Scalars['String']>;
+  fundingRound_starts_with: Maybe<Scalars['String']>;
+  fundingRound_not_starts_with: Maybe<Scalars['String']>;
+  fundingRound_ends_with: Maybe<Scalars['String']>;
+  fundingRound_not_ends_with: Maybe<Scalars['String']>;
+  timestamp: Maybe<Scalars['String']>;
+  timestamp_not: Maybe<Scalars['String']>;
+  timestamp_gt: Maybe<Scalars['String']>;
+  timestamp_lt: Maybe<Scalars['String']>;
+  timestamp_gte: Maybe<Scalars['String']>;
+  timestamp_lte: Maybe<Scalars['String']>;
+  timestamp_in: Maybe<Array<Scalars['String']>>;
+  timestamp_not_in: Maybe<Array<Scalars['String']>>;
+  timestamp_contains: Maybe<Scalars['String']>;
+  timestamp_not_contains: Maybe<Scalars['String']>;
+  timestamp_starts_with: Maybe<Scalars['String']>;
+  timestamp_not_starts_with: Maybe<Scalars['String']>;
+  timestamp_ends_with: Maybe<Scalars['String']>;
+  timestamp_not_ends_with: Maybe<Scalars['String']>;
+};
+
+export enum Message_OrderBy {
+  Id = 'id',
+  Data = 'data',
+  Iv = 'iv',
+  PublicKey = 'publicKey',
+  FundingRound = 'fundingRound',
+  Timestamp = 'timestamp'
+}
+
 export enum OrderDirection {
   Asc = 'asc',
   Desc = 'desc'
+}
+
+export type PublicKey = {
+  __typename?: 'PublicKey';
+  id: Scalars['ID'];
+  fundingRound: Maybe<FundingRound>;
+  messages: Maybe<Array<Message>>;
+  x: Scalars['BigInt'];
+  y: Scalars['BigInt'];
+  stateIndex: Maybe<Scalars['BigInt']>;
+  voiceCreditBalance: Maybe<Scalars['BigInt']>;
+};
+
+
+export type PublicKeyMessagesArgs = {
+  skip?: Maybe<Scalars['Int']>;
+  first?: Maybe<Scalars['Int']>;
+  orderBy: Maybe<Message_OrderBy>;
+  orderDirection: Maybe<OrderDirection>;
+  where: Maybe<Message_Filter>;
+};
+
+export type PublicKey_Filter = {
+  id: Maybe<Scalars['ID']>;
+  id_not: Maybe<Scalars['ID']>;
+  id_gt: Maybe<Scalars['ID']>;
+  id_lt: Maybe<Scalars['ID']>;
+  id_gte: Maybe<Scalars['ID']>;
+  id_lte: Maybe<Scalars['ID']>;
+  id_in: Maybe<Array<Scalars['ID']>>;
+  id_not_in: Maybe<Array<Scalars['ID']>>;
+  fundingRound: Maybe<Scalars['String']>;
+  fundingRound_not: Maybe<Scalars['String']>;
+  fundingRound_gt: Maybe<Scalars['String']>;
+  fundingRound_lt: Maybe<Scalars['String']>;
+  fundingRound_gte: Maybe<Scalars['String']>;
+  fundingRound_lte: Maybe<Scalars['String']>;
+  fundingRound_in: Maybe<Array<Scalars['String']>>;
+  fundingRound_not_in: Maybe<Array<Scalars['String']>>;
+  fundingRound_contains: Maybe<Scalars['String']>;
+  fundingRound_not_contains: Maybe<Scalars['String']>;
+  fundingRound_starts_with: Maybe<Scalars['String']>;
+  fundingRound_not_starts_with: Maybe<Scalars['String']>;
+  fundingRound_ends_with: Maybe<Scalars['String']>;
+  fundingRound_not_ends_with: Maybe<Scalars['String']>;
+  x: Maybe<Scalars['BigInt']>;
+  x_not: Maybe<Scalars['BigInt']>;
+  x_gt: Maybe<Scalars['BigInt']>;
+  x_lt: Maybe<Scalars['BigInt']>;
+  x_gte: Maybe<Scalars['BigInt']>;
+  x_lte: Maybe<Scalars['BigInt']>;
+  x_in: Maybe<Array<Scalars['BigInt']>>;
+  x_not_in: Maybe<Array<Scalars['BigInt']>>;
+  y: Maybe<Scalars['BigInt']>;
+  y_not: Maybe<Scalars['BigInt']>;
+  y_gt: Maybe<Scalars['BigInt']>;
+  y_lt: Maybe<Scalars['BigInt']>;
+  y_gte: Maybe<Scalars['BigInt']>;
+  y_lte: Maybe<Scalars['BigInt']>;
+  y_in: Maybe<Array<Scalars['BigInt']>>;
+  y_not_in: Maybe<Array<Scalars['BigInt']>>;
+  stateIndex: Maybe<Scalars['BigInt']>;
+  stateIndex_not: Maybe<Scalars['BigInt']>;
+  stateIndex_gt: Maybe<Scalars['BigInt']>;
+  stateIndex_lt: Maybe<Scalars['BigInt']>;
+  stateIndex_gte: Maybe<Scalars['BigInt']>;
+  stateIndex_lte: Maybe<Scalars['BigInt']>;
+  stateIndex_in: Maybe<Array<Scalars['BigInt']>>;
+  stateIndex_not_in: Maybe<Array<Scalars['BigInt']>>;
+  voiceCreditBalance: Maybe<Scalars['BigInt']>;
+  voiceCreditBalance_not: Maybe<Scalars['BigInt']>;
+  voiceCreditBalance_gt: Maybe<Scalars['BigInt']>;
+  voiceCreditBalance_lt: Maybe<Scalars['BigInt']>;
+  voiceCreditBalance_gte: Maybe<Scalars['BigInt']>;
+  voiceCreditBalance_lte: Maybe<Scalars['BigInt']>;
+  voiceCreditBalance_in: Maybe<Array<Scalars['BigInt']>>;
+  voiceCreditBalance_not_in: Maybe<Array<Scalars['BigInt']>>;
+};
+
+export enum PublicKey_OrderBy {
+  Id = 'id',
+  FundingRound = 'fundingRound',
+  Messages = 'messages',
+  X = 'x',
+  Y = 'y',
+  StateIndex = 'stateIndex',
+  VoiceCreditBalance = 'voiceCreditBalance'
 }
 
 export type Query = {
   __typename?: 'Query';
   fundingRoundFactory: Maybe<FundingRoundFactory>;
   fundingRoundFactories: Array<FundingRoundFactory>;
+  message: Maybe<Message>;
+  messages: Array<Message>;
+  publicKey: Maybe<PublicKey>;
+  publicKeys: Array<PublicKey>;
   fundingRound: Maybe<FundingRound>;
   fundingRounds: Array<FundingRound>;
   recipientRegistry: Maybe<RecipientRegistry>;
@@ -1149,6 +1335,38 @@ export type QueryFundingRoundFactoriesArgs = {
   orderBy: Maybe<FundingRoundFactory_OrderBy>;
   orderDirection: Maybe<OrderDirection>;
   where: Maybe<FundingRoundFactory_Filter>;
+  block: Maybe<Block_Height>;
+};
+
+
+export type QueryMessageArgs = {
+  id: Scalars['ID'];
+  block: Maybe<Block_Height>;
+};
+
+
+export type QueryMessagesArgs = {
+  skip?: Maybe<Scalars['Int']>;
+  first?: Maybe<Scalars['Int']>;
+  orderBy: Maybe<Message_OrderBy>;
+  orderDirection: Maybe<OrderDirection>;
+  where: Maybe<Message_Filter>;
+  block: Maybe<Block_Height>;
+};
+
+
+export type QueryPublicKeyArgs = {
+  id: Scalars['ID'];
+  block: Maybe<Block_Height>;
+};
+
+
+export type QueryPublicKeysArgs = {
+  skip?: Maybe<Scalars['Int']>;
+  first?: Maybe<Scalars['Int']>;
+  orderBy: Maybe<PublicKey_OrderBy>;
+  orderDirection: Maybe<OrderDirection>;
+  where: Maybe<PublicKey_Filter>;
   block: Maybe<Block_Height>;
 };
 
@@ -1670,6 +1888,10 @@ export type Subscription = {
   __typename?: 'Subscription';
   fundingRoundFactory: Maybe<FundingRoundFactory>;
   fundingRoundFactories: Array<FundingRoundFactory>;
+  message: Maybe<Message>;
+  messages: Array<Message>;
+  publicKey: Maybe<PublicKey>;
+  publicKeys: Array<PublicKey>;
   fundingRound: Maybe<FundingRound>;
   fundingRounds: Array<FundingRound>;
   recipientRegistry: Maybe<RecipientRegistry>;
@@ -1707,6 +1929,38 @@ export type SubscriptionFundingRoundFactoriesArgs = {
   orderBy: Maybe<FundingRoundFactory_OrderBy>;
   orderDirection: Maybe<OrderDirection>;
   where: Maybe<FundingRoundFactory_Filter>;
+  block: Maybe<Block_Height>;
+};
+
+
+export type SubscriptionMessageArgs = {
+  id: Scalars['ID'];
+  block: Maybe<Block_Height>;
+};
+
+
+export type SubscriptionMessagesArgs = {
+  skip?: Maybe<Scalars['Int']>;
+  first?: Maybe<Scalars['Int']>;
+  orderBy: Maybe<Message_OrderBy>;
+  orderDirection: Maybe<OrderDirection>;
+  where: Maybe<Message_Filter>;
+  block: Maybe<Block_Height>;
+};
+
+
+export type SubscriptionPublicKeyArgs = {
+  id: Scalars['ID'];
+  block: Maybe<Block_Height>;
+};
+
+
+export type SubscriptionPublicKeysArgs = {
+  skip?: Maybe<Scalars['Int']>;
+  first?: Maybe<Scalars['Int']>;
+  orderBy: Maybe<PublicKey_OrderBy>;
+  orderDirection: Maybe<OrderDirection>;
+  where: Maybe<PublicKey_Filter>;
   block: Maybe<Block_Height>;
 };
 
@@ -2099,12 +2353,10 @@ export type GetRecipientDonationsQueryVariables = Exact<{
 
 export type GetRecipientDonationsQuery = { __typename?: 'Query', fundingRound: Maybe<{ __typename?: 'FundingRound', recipientRegistry: Maybe<{ __typename?: 'RecipientRegistry', recipients: Maybe<Array<{ __typename?: 'Recipient', donations: Maybe<Array<{ __typename?: 'Donation', id: string }>> }>> }> }> };
 
-export type GetRecipientsQueryVariables = Exact<{
-  registryAddress: Scalars['ID'];
-}>;
+export type GetRecipientsQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type GetRecipientsQuery = { __typename?: 'Query', recipientRegistry: Maybe<{ __typename?: 'RecipientRegistry', recipients: Maybe<Array<{ __typename?: 'Recipient', id: string, recipientIndex: Maybe<any>, requestType: Maybe<string>, requester: Maybe<string>, recipientAddress: Maybe<any>, recipientMetadata: Maybe<string>, requestSubmittedHash: Maybe<any>, requestResolvedHash: Maybe<any>, submissionTime: Maybe<string>, rejected: Maybe<boolean>, verified: Maybe<boolean> }>> }> };
+export type GetRecipientsQuery = { __typename?: 'Query', recipients: Array<{ __typename?: 'Recipient', id: string, recipientIndex: Maybe<any>, requestType: Maybe<string>, requester: Maybe<string>, recipientAddress: Maybe<any>, recipientMetadata: Maybe<string>, requestSubmittedHash: Maybe<any>, requestResolvedHash: Maybe<any>, submissionTime: Maybe<string>, rejected: Maybe<boolean>, verified: Maybe<boolean> }> };
 
 export type GetRoundsQueryVariables = Exact<{ [key: string]: never; }>;
 
@@ -2187,21 +2439,19 @@ export const GetRecipientDonationsDocument = gql`
 }
     `;
 export const GetRecipientsDocument = gql`
-    query GetRecipients($registryAddress: ID!) {
-  recipientRegistry(id: $registryAddress) {
-    recipients {
-      id
-      recipientIndex
-      requestType
-      requester
-      recipientAddress
-      recipientMetadata
-      requestSubmittedHash
-      requestResolvedHash
-      submissionTime
-      rejected
-      verified
-    }
+    query GetRecipients {
+  recipients {
+    id
+    recipientIndex
+    requestType
+    requester
+    recipientAddress
+    recipientMetadata
+    requestSubmittedHash
+    requestResolvedHash
+    submissionTime
+    rejected
+    verified
   }
 }
     `;
@@ -2247,7 +2497,7 @@ export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = 
     GetRecipientDonations(variables: GetRecipientDonationsQueryVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<GetRecipientDonationsQuery> {
       return withWrapper((wrappedRequestHeaders) => client.request<GetRecipientDonationsQuery>(GetRecipientDonationsDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'GetRecipientDonations');
     },
-    GetRecipients(variables: GetRecipientsQueryVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<GetRecipientsQuery> {
+    GetRecipients(variables?: GetRecipientsQueryVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<GetRecipientsQuery> {
       return withWrapper((wrappedRequestHeaders) => client.request<GetRecipientsQuery>(GetRecipientsDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'GetRecipients');
     },
     GetRounds(variables?: GetRoundsQueryVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<GetRoundsQuery> {

--- a/vue-app/src/graphql/queries/GetRecipients.graphql
+++ b/vue-app/src/graphql/queries/GetRecipients.graphql
@@ -1,17 +1,15 @@
-query GetRecipients($registryAddress: ID!) {
-  recipientRegistry(id: $registryAddress) {
-    recipients {
-      id
-      recipientIndex
-      requestType
-      requester
-      recipientAddress
-      recipientMetadata
-      requestSubmittedHash
-      requestResolvedHash
-      submissionTime
-      rejected
-      verified
-    }
+query GetRecipients {
+  recipients {
+    id
+    recipientIndex
+    requestType
+    requester
+    recipientAddress
+    recipientMetadata
+    requestSubmittedHash
+    requestResolvedHash
+    submissionTime
+    rejected
+    verified
   }
 }

--- a/vue-app/src/views/RecipientRegistry.vue
+++ b/vue-app/src/views/RecipientRegistry.vue
@@ -183,12 +183,8 @@ export default class RecipientRegistryView extends Vue {
   }
 
   async loadRequests() {
-    const { recipientRegistryAddress, recipientRegistryInfo } =
-      this.$store.state
-    this.requests = await getRequests(
-      recipientRegistryAddress,
-      recipientRegistryInfo
-    )
+    const { recipientRegistryInfo } = this.$store.state
+    this.requests = await getRequests(recipientRegistryInfo)
   }
 
   get registryInfo(): RegistryInfo {


### PR DESCRIPTION
Changed the `GetRecipients` query to fetch directly from the `recipients` field instead of going through the `recipientRegistry` field.

In the join phase, the `recipientRegistry` field doesn't get populated until the round is started. The `recipients` field is populated no matter when a round is started.