### PR TITLE
Swaps clr.fund logo back into site nav

### DIFF
--- a/vue-app/src/components/NavBar.vue
+++ b/vue-app/src/components/NavBar.vue
@@ -1,6 +1,6 @@
 <template>
   <nav id="nav-bar">
-    <links :to="inApp ? '/projects' : '/'">
+    <links to="/">
       <img class="clr-logo" alt="clr fund" src="@/assets/clr.svg" />
     </links>
     <div class="btn-row">
@@ -31,7 +31,6 @@
           </div>
         </div>
       </div>
-      <!-- <div class="desktop"><cart-widget v-if="inApp" /></div> -->
       <wallet-widget class="wallet-widget" v-if="inApp" />
       <links v-if="!inApp" to="/projects" class="app-btn">App</links>
     </div>

--- a/vue-app/src/components/NavBar.vue
+++ b/vue-app/src/components/NavBar.vue
@@ -1,18 +1,7 @@
 <template>
   <nav id="nav-bar">
-    <links v-if="!inApp" to="/">
-      <img
-        class="ef-logo"
-        alt="ethereum foundation"
-        src="@/assets/eth-diamond-rainbow.svg"
-      />
-    </links>
-    <links v-else to="/projects">
-      <img
-        class="ef-logo"
-        alt="ethereum foundation"
-        src="@/assets/eth-diamond-rainbow.svg"
-      />
+    <links :to="inApp ? '/projects' : '/'">
+      <img class="clr-logo" alt="clr fund" src="@/assets/clr.svg" />
     </links>
     <div class="btn-row">
       <a
@@ -167,7 +156,7 @@ export default class NavBar extends Vue {
     font-size: 16px;
   }
 
-  .ef-logo {
+  .clr-logo {
     margin: 0;
     height: 2.25rem;
     vertical-align: middle;


### PR DESCRIPTION
### Description
- Swaps the `clr.svg` logo back into site nav

Kept `eth-diamond-rainbow.svg` in the repo, but we could potentially remove this.

### Related issues
Fixes: https://github.com/ethereum/clrfund/projects/3#card-70207759