### PR TITLE
MACI cap explanations [Fixed #132]

### DIFF
--- a/vue-app/src/views/VerifyLanding.vue
+++ b/vue-app/src/views/VerifyLanding.vue
@@ -50,20 +50,20 @@
           <li>Access to Zoom or Google Meet</li>
         </ul>
         <links to="/about-sybil-resistance/">Why is this important?</links>
-        <div
-          v-if="
-            $store.getters.isRoundJoinPhase &&
-            !currentRound &&
-            !isRoundFullOrOver
-          "
-          class="join-message"
-        >
+        <div v-if="isRoundNotStarted" class="join-message">
           There's not yet an open funding round. Get prepared now so you're
           ready for when the next one begins!
         </div>
-        <div v-if="isRoundFullOrOver" class="warning-message">
+        <div v-else-if="isRoundOver" class="warning-message">
           The current round is no longer accepting new contributions. You can
           still get BrightID verified to prepare for next time.
+        </div>
+        <div v-else-if="isRoundFull" class="warning-message">
+          Contributions closed early – you can no longer donate! Due to the
+          community's generosity and some technical constraints we had to close
+          the round earlier than expected. If you already contributed, you still
+          have time to reallocate if you need to. If you didn't get a chance to
+          contribute, you can still help by donating to the matching pool
         </div>
         <div class="btn-container mt2">
           <wallet-widget
@@ -128,18 +128,16 @@ export default class VerifyLanding extends Vue {
     return commify(formatUnits(balance, 18))
   }
 
-  get isRoundFullOrOver(): boolean {
-    const currentRound = this.$store.state.currentRound
-    if (!currentRound) {
-      return false
-    }
-    const hasHitMaxContributors =
-      currentRound.maxContributors <= currentRound.contributors
-    return (
-      this.$store.getters.hasContributionPhaseEnded ||
-      this.$store.getters.isMessageLimitReached ||
-      hasHitMaxContributors
-    )
+  get isRoundNotStarted(): boolean {
+    return this.$store.getters.isRoundJoinPhase
+  }
+
+  get isRoundFull(): boolean {
+    return this.$store.getters.isRoundContributorLimitReached
+  }
+
+  get isRoundOver(): boolean {
+    return this.$store.getters.hasContributionPhaseEnded
   }
 
   formatDuration(value: number): string {


### PR DESCRIPTION
> "Contributions closed early – you can no longer donate! Due to the community's generosity and some technical constraints we had to close the round earlier than expected. If you already contributed, you still have time to reallocate if you need to. If you didn't get a chance to contribute, you can still help by donating to the matching pool"

> If `maxContributors` is hit, I think we could just display this on the verify page: https://eth2clrfund.netlify.app/#/verify

Added this copy to `VerifyLanding.vue` page. Cleaned up some of the getters here while in there.


> "The round is officially closed – it's now too late to contribute or reallocate your donations! Due to the community's generosity and some technical constraints we had to close the round earlier than expected. You can still help by donating to the matching pool"

> If `maxMessages` is hit, this affects every user (both contributors, reallocators & recipients) so perhaps we pop the modal when anyone connects their wallet (then perhaps use local storage to hide the modal on subsequent reconnects?).

Commented in #132 about this... suggesting a less obtrusive notice that displays in the RoundInformation section.

![image](https://user-images.githubusercontent.com/54227730/136894740-5c6a0a7d-698a-4dff-92eb-f5a2a74f80f0.png)

This is a screenshot of what this PR adds. This seemed fitting as it _is_ round information, and accomplishes the same thing as a modal without the pop-up. Used the `warning` color scheme. Uses localStorage to store dismissal boolean, round-specific.

Certainly open to feedback, and can rebuild as a modal if that's what folks would prefer. 