### PR TITLE
Revert optimistic changes

### DIFF
--- a/contracts/contracts/recipientRegistry/OptimisticRecipientRegistry.sol
+++ b/contracts/contracts/recipientRegistry/OptimisticRecipientRegistry.sol
@@ -124,12 +124,12 @@ contract OptimisticRecipientRegistry is Ownable, BaseRecipientRegistry {
     */
   function removeRecipient(bytes32 _recipientId)
     external
-    onlyOwner
     payable
   {
     require(recipients[_recipientId].index != 0, 'RecipientRegistry: Recipient is not in the registry');
     require(recipients[_recipientId].removedAt == 0, 'RecipientRegistry: Recipient already removed');
     require(requests[_recipientId].submissionTime == 0, 'RecipientRegistry: Request already submitted');
+    require(msg.value == baseDeposit, 'RecipientRegistry: Incorrect deposit amount');
     requests[_recipientId] = Request(
       RequestType.Removal,
       msg.sender,

--- a/vue-app/src/api/recipient-registry-optimistic.ts
+++ b/vue-app/src/api/recipient-registry-optimistic.ts
@@ -183,7 +183,7 @@ export async function getRequests(
     const request: Request = {
       transactionHash:
         recipient.requestResolvedHash || recipient.requestSubmittedHash,
-      type: RequestType[requestType],
+      type: RequestType[RequestTypeCode[requestType]],
       status: RequestStatus.Submitted,
       acceptanceDate,
       recipientId: recipient.id,

--- a/vue-app/src/components/TransactionModal.vue
+++ b/vue-app/src/components/TransactionModal.vue
@@ -1,0 +1,80 @@
+<template>
+  <div class="modal-body">
+    <transaction
+      :hash="txHash"
+      :error="txError"
+      :displayRetryBtn="true"
+      @close="$emit('close')"
+      @retry="
+        () => {
+          this.txError = ''
+          executeTx()
+        }
+      "
+    ></transaction>
+    <button
+      v-if="txHash"
+      class="btn-secondary close-btn"
+      @click="$emit('close')"
+    >
+      Close
+    </button>
+  </div>
+</template>
+
+<script lang="ts">
+import Vue from 'vue'
+import Component from 'vue-class-component'
+import { Prop } from 'vue-property-decorator'
+import { TransactionResponse } from '@ethersproject/abstract-provider'
+
+import Transaction from '@/components/Transaction.vue'
+import { waitForTransaction } from '@/utils/contracts'
+
+@Component({
+  components: {
+    Transaction,
+  },
+})
+export default class TransactionModal extends Vue {
+  @Prop() transactionFn!: () => Promise<TransactionResponse>
+  @Prop() onTxSuccess!: (txHash) => void
+
+  txHash = ''
+  txError = ''
+
+  mounted() {
+    this.executeTx()
+  }
+
+  private async executeTx() {
+    try {
+      await waitForTransaction(
+        this.transactionFn(),
+        (hash) => (this.txHash = hash)
+      )
+
+      this.onTxSuccess(this.txHash)
+    } catch (error) {
+      this.txError = error.message
+      return
+    }
+  }
+}
+</script>
+
+<style scoped lang="scss">
+@import '../styles/vars';
+
+.modal-body {
+  text-align: left;
+  background: $bg-secondary-color;
+  border-radius: 1rem;
+  box-shadow: $box-shadow;
+  padding: 1.5rem;
+}
+
+.close-btn {
+  margin-top: $modal-space;
+}
+</style>

--- a/vue-app/src/store/getters.ts
+++ b/vue-app/src/store/getters.ts
@@ -49,6 +49,9 @@ const getters = {
       seconds: challengePeriodDuration,
     })
   },
+  isChallengePeriod: (_state: RootState, getters) => {
+    return !hasDateElapsed(getters.recipientJoinDeadline)
+  },
   isRoundJoinPhase: (state: RootState, getters): boolean => {
     if (!state.currentRound) {
       return true
@@ -56,7 +59,7 @@ const getters = {
     if (!state.recipientRegistryInfo) {
       return false
     }
-    return !hasDateElapsed(getters.recipientJoinDeadline)
+    return getters.isChallengePeriod
   },
   isRoundJoinOnlyPhase: (state: RootState, getters): boolean => {
     return (

--- a/vue-app/src/store/getters.ts
+++ b/vue-app/src/store/getters.ts
@@ -49,9 +49,6 @@ const getters = {
       seconds: challengePeriodDuration,
     })
   },
-  isChallengePeriod: (_state: RootState, getters) => {
-    return !hasDateElapsed(getters.recipientJoinDeadline)
-  },
   isRoundJoinPhase: (state: RootState, getters): boolean => {
     if (!state.currentRound) {
       return true
@@ -59,7 +56,7 @@ const getters = {
     if (!state.recipientRegistryInfo) {
       return false
     }
-    return getters.isChallengePeriod
+    return !hasDateElapsed(getters.recipientJoinDeadline)
   },
   isRoundJoinOnlyPhase: (state: RootState, getters): boolean => {
     return (

--- a/vue-app/src/views/RecipientRegistry.vue
+++ b/vue-app/src/views/RecipientRegistry.vue
@@ -109,15 +109,18 @@
               </div> -->
                 <div
                   class="icon-btn-approve"
+                  v-if="
+                    (isOwner || (!isOwner && !isChallengePeriod)) &&
+                    isPending(request)
+                  "
                   @click="approve(request)"
-                  v-if="isPending(request)"
                 >
                   <img src="@/assets/checkmark.svg" />
                 </div>
                 <div
                   class="icon-btn-reject"
+                  v-if="isOwner && isPending(request)"
                   @click="reject(request)"
-                  v-if="isPending(request)"
                 >
                   <img src="@/assets/close.svg" />
                 </div>
@@ -151,7 +154,6 @@ import Loader from '@/components/Loader.vue'
 import Links from '@/components/Links.vue'
 import { formatAmount } from '@/utils/amounts'
 import { markdown } from '@/utils/markdown'
-import { waitForTransaction } from '@/utils/contracts'
 import { LOAD_RECIPIENT_REGISTRY_INFO } from '@/store/action-types'
 import { RegistryInfo } from '@/api/recipient-registry-optimistic'
 import TransactionModal from '@/components/TransactionModal.vue'
@@ -169,6 +171,14 @@ export default class RecipientRegistryView extends Vue {
     await this.$store.dispatch(LOAD_RECIPIENT_REGISTRY_INFO)
     await this.loadRequests()
     this.isLoading = false
+  }
+
+  get isOwner() {
+    return this.$store.getters.isRecipientRegistryOwner
+  }
+
+  get isChallengePeriod() {
+    return this.$store.getters.isChallengePeriod
   }
 
   get isUserConnected(): boolean {

--- a/vue-app/src/views/RecipientRegistry.vue
+++ b/vue-app/src/views/RecipientRegistry.vue
@@ -1,111 +1,112 @@
 <template>
   <div class="recipients">
-    <div v-if="$store.getters.isRecipientRegistryOwner">
-      <div class="title">
-        <div class="header">
-          <h2>Recipient registry</h2>
-        </div>
-        <div class="hr" />
+    <div class="title">
+      <div class="header">
+        <h2>Recipient registry</h2>
       </div>
-      <loader v-if="isLoading" />
-      <div v-else>
-        <table class="requests">
-          <thead>
-            <tr>
-              <th>Project</th>
-              <th>Request type</th>
-              <th>Status</th>
-              <th>Actions</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr
-              v-for="request in requests.slice().reverse()"
-              :key="request.transactionHash"
-            >
-              <td>
-                <div class="project-name">
-                  <links :to="request.metadata.thumbnailImageUrl">
-                    <img
-                      class="project-image"
-                      :src="request.metadata.thumbnailImageUrl"
-                    />
-                  </links>
-                  {{ request.metadata.name }}
-                  <links
-                    v-if="hasProjectLink(request)"
-                    :to="{
-                      name: 'project',
-                      params: { id: request.recipientId },
-                    }"
-                    >-></links
-                  >
-                </div>
-                <details class="project-details">
-                  <summary>More</summary>
-
-                  <div>
-                    <span
-                      >Transaction hash
-                      <button
-                        class="button-copy"
-                        @click="copyAddress(request.transactionHash)"
-                      >
-                        <img src="@/assets/copy.svg" />
-                      </button>
-                    </span>
-                    <code>{{ request.transactionHash }}</code>
-                  </div>
-                  <div>
-                    <span
-                      >Project ID
-                      <button
-                        class="button-copy"
-                        @click="copyAddress(request.recipientId)"
-                      >
-                        <img src="@/assets/copy.svg" />
-                      </button>
-                    </span>
-                    <code>{{ request.recipientId }}</code>
-                  </div>
-                  <div>
-                    <span
-                      >Recipient address
-                      <button
-                        class="button-copy"
-                        @click="copyAddress(request.recipient)"
-                      >
-                        <img src="@/assets/copy.svg" />
-                      </button>
-                    </span>
-                    <code>{{ request.recipient }}</code>
-                  </div>
-                </details>
-              </td>
-              <td>{{ request.type }}</td>
-              <td>
-                <template v-if="hasProjectLink(request)">
-                  <links
-                    :to="{
-                      name: 'project',
-                      params: { id: request.recipientId },
-                    }"
-                  >
-                    {{ request.status }}
-                  </links>
-                </template>
-                <template v-else>
-                  {{ request.status }}
-                </template>
-              </td>
-              <td class="actions">
-                <div
-                  class="btn-warning"
-                  @click="remove(request)"
-                  v-if="isExecuted(request)"
+      <div class="hr" />
+    </div>
+    <loader v-if="isLoading" />
+    <div v-else>
+      <table class="requests">
+        <thead>
+          <tr>
+            <th>Project</th>
+            <th>Request type</th>
+            <th>Status</th>
+            <th>Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr
+            v-for="request in requests.slice().reverse()"
+            :key="request.transactionHash"
+          >
+            <td>
+              <div class="project-name">
+                <links :to="request.metadata.thumbnailImageUrl">
+                  <img
+                    class="project-image"
+                    :src="request.metadata.thumbnailImageUrl"
+                  />
+                </links>
+                {{ request.metadata.name }}
+                <links
+                  v-if="hasProjectLink(request)"
+                  :to="{
+                    name: 'project',
+                    params: { id: request.recipientId },
+                  }"
+                  >-></links
                 >
-                  Remove
+              </div>
+              <details class="project-details">
+                <summary>More</summary>
+
+                <div>
+                  <span
+                    >Transaction hash
+                    <button
+                      class="button-copy"
+                      @click="copyAddress(request.transactionHash)"
+                    >
+                      <img src="@/assets/copy.svg" />
+                    </button>
+                  </span>
+                  <code>{{ request.transactionHash }}</code>
                 </div>
+                <div>
+                  <span
+                    >Project ID
+                    <button
+                      class="button-copy"
+                      @click="copyAddress(request.recipientId)"
+                    >
+                      <img src="@/assets/copy.svg" />
+                    </button>
+                  </span>
+                  <code>{{ request.recipientId }}</code>
+                </div>
+                <div>
+                  <span
+                    >Recipient address
+                    <button
+                      class="button-copy"
+                      @click="copyAddress(request.recipient)"
+                    >
+                      <img src="@/assets/copy.svg" />
+                    </button>
+                  </span>
+                  <code>{{ request.recipient }}</code>
+                </div>
+              </details>
+            </td>
+            <td>{{ request.type }}</td>
+            <td>
+              <template v-if="hasProjectLink(request)">
+                <links
+                  :to="{
+                    name: 'project',
+                    params: { id: request.recipientId },
+                  }"
+                >
+                  {{ request.status }}
+                </links>
+              </template>
+              <template v-else>
+                {{ request.status }}
+              </template>
+            </td>
+            <td>
+              <div class="actions" v-if="isUserConnected">
+                <!-- TODO: to implement this feature, it requires to send a baseDeposit (see contract)
+              <div
+                class="btn-warning"
+                @click="remove(request)"
+                v-if="isExecuted(request)"
+              >
+                Remove
+              </div> -->
                 <div
                   class="icon-btn-approve"
                   @click="approve(request)"
@@ -120,20 +121,11 @@
                 >
                   <img src="@/assets/close.svg" />
                 </div>
-              </td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
-    </div>
-    <div v-else>
-      <div class="big-emoji" aria-label="hand">🤚</div>
-      <h2>
-        You must be the recipient registry contract owner to access this page
-      </h2>
-      <div v-if="!isUserConnected">
-        <h2>Please connect your wallet.</h2>
-      </div>
+              </div>
+            </td>
+          </tr>
+        </tbody>
+      </table>
     </div>
   </div>
 </template>
@@ -349,7 +341,7 @@ export default class RecipientRegistryView extends Vue {
       word-wrap: break-word;
     }
 
-    &.actions {
+    .actions {
       display: flex;
     }
 

--- a/vue-app/src/views/RecipientRegistry.vue
+++ b/vue-app/src/views/RecipientRegistry.vue
@@ -110,7 +110,7 @@
                 <div
                   class="icon-btn-approve"
                   v-if="
-                    (isOwner || (!isOwner && !isChallengePeriod)) &&
+                    (isOwner || (!isOwner && isChallengePeriodOver(request))) &&
                     isPending(request)
                   "
                   @click="approve(request)"
@@ -177,10 +177,6 @@ export default class RecipientRegistryView extends Vue {
     return this.$store.getters.isRecipientRegistryOwner
   }
 
-  get isChallengePeriod() {
-    return this.$store.getters.isChallengePeriod
-  }
-
   get isUserConnected(): boolean {
     return !!this.$store.state.currentUser
   }
@@ -227,6 +223,10 @@ export default class RecipientRegistryView extends Vue {
       request.type === RequestType.Registration &&
       request.status === RequestStatus.Executed
     )
+  }
+
+  isChallengePeriodOver(request: Request): boolean {
+    return Date.now() > request.acceptanceDate.toMillis()
   }
 
   async approve(request: Request): Promise<void> {


### PR DESCRIPTION
Tackle #432

- Reverted OptimisticRecipientReg contract changes.
- Made the `/recipients` page visible/accessible to everyone.
- Hide Approve/Register button when in challenge period and the user is not the owner
- Hide Reject/Challenge button when the user is not the owner
- Temporarily hide the "Remove" button from the Recipients view as it requires a base deposit (I think we can work on this after the merge).
- Added a generic `TransactionModal` component to see a tx progress.