### PR TITLE
Email required only if Google spreadsheet info available [Fixes #429]

### DIFF
--- a/vue-app/.env.example
+++ b/vue-app/.env.example
@@ -32,4 +32,4 @@ VUE_APP_OPERATOR=
 # Google Service Account credentials in JSON format
 GOOGLE_APPLICATION_CREDENTIALS=
 # Spreadsheet ID to send recipients data
-GOOGLE_SPREADSHEET_ID=
+VUE_APP_GOOGLE_SPREADSHEET_ID=

--- a/vue-app/src/components/RecipientSubmissionWidget.vue
+++ b/vue-app/src/components/RecipientSubmissionWidget.vue
@@ -222,13 +222,15 @@ export default class RecipientSubmissionWidget extends Vue {
         )
 
         // Send application data to a Google Spreadsheet
-        await fetch('/.netlify/functions/recipient', {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-          },
-          body: JSON.stringify(recipient),
-        })
+        if (process.env.VUE_APP_GOOGLE_SPREADSHEET_ID) {
+          await fetch('/.netlify/functions/recipient', {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+            },
+            body: JSON.stringify(recipient),
+          })
+        }
 
         this.$store.commit(RESET_RECIPIENT_DATA)
       } catch (error) {

--- a/vue-app/src/lambda/recipient.js
+++ b/vue-app/src/lambda/recipient.js
@@ -48,7 +48,7 @@ exports.handler = async function (event) {
     const recipient = JSON.parse(event.body)
 
     const creds = JSON.parse(process.env.GOOGLE_APPLICATION_CREDENTIALS)
-    const doc = new GoogleSpreadsheet(process.env.GOOGLE_SPREADSHEET_ID)
+    const doc = new GoogleSpreadsheet(process.env.VUE_APP_GOOGLE_SPREADSHEET_ID)
     await doc.useServiceAccountAuth(creds)
 
     await doc.loadInfo()

--- a/vue-app/src/views/Join.vue
+++ b/vue-app/src/views/Join.vue
@@ -291,10 +291,10 @@
             <h2 class="step-title">Team details</h2>
             <p>Tell us about the folks behind your project.</p>
             <div class="inputs">
-              <div class="form-background">
-                <label for="team-email" class="input-label"
-                  >Contact email</label
-                >
+              <div v-if="isEmailRequired" class="form-background">
+                <label for="team-email" class="input-label">
+                  Contact email
+                </label>
                 <p class="input-description">
                   For important updates about your project and the funding
                   round.
@@ -577,7 +577,7 @@
                     >Edit <img width="16px" src="@/assets/edit.svg"
                   /></links>
                 </div>
-                <div class="summary">
+                <div v-if="isEmailRequired" class="summary">
                   <h4 class="read-only-title">Contact email</h4>
                   <div class="data">{{ form.team.email }}</div>
                   <div class="input-notice">
@@ -797,7 +797,9 @@ import { chain } from '@/api/core'
         description: {},
         email: {
           email,
-          required,
+          required: process.env.VUE_APP_GOOGLE_SPREADSHEET_ID
+            ? required
+            : () => true,
         },
       },
       links: {
@@ -890,6 +892,10 @@ export default class JoinView extends mixins(validationMixin) {
         params: { step: steps[this.form.furthestStep] },
       })
     }
+  }
+
+  get isEmailRequired(): boolean {
+    return !!process.env.VUE_APP_GOOGLE_SPREADSHEET_ID
   }
 
   handleToggleTab(event): void {


### PR DESCRIPTION
### Description
- If no Google spreadsheet credentials are provided in `vue-app/.env` the `email` field on the recipient Join form will no longer be displayed.
- Validation adjusted to not require this field if the google spreadsheet ID is not provided in `vue-app/.env`
- Changes `.env` variable from `GOOGLE_SPREADSHEET_ID` to `VUE_APP_GOOGLE_SPREADSHEET_ID` to expose it to the Vue front-end. `GOOGLE_APPLICATION_CREDENTIALS` is left unchanged for security reasons, only exposed via the lambda function.

## Related issue
#429