### PR TITLE
Remove voting deadline check when a recipient is added

### DIFF
--- a/vue-app/src/components/RecipientSubmissionWidget.vue
+++ b/vue-app/src/components/RecipientSubmissionWidget.vue
@@ -184,7 +184,6 @@ export default class RecipientSubmissionWidget extends Vue {
 
   private async addRecipient() {
     const {
-      currentRound,
       currentUser,
       recipient,
       recipientRegistryAddress,
@@ -204,13 +203,6 @@ export default class RecipientSubmissionWidget extends Vue {
       currentUser
     ) {
       try {
-        if (DateTime.now() >= currentRound.votingDeadline) {
-          this.$router.push({
-            name: 'join',
-          })
-          throw { message: 'round over' }
-        }
-
         await waitForTransaction(
           addRecipient(
             recipientRegistryAddress,


### PR DESCRIPTION
In join phase, we should be able to add a new recipient, so we shouldn't be checking the voting deadline (that is obtained from the round).