### PR TITLE
Only check votingDeadline if currentRound exists

### DIFF
--- a/vue-app/src/components/RecipientSubmissionWidget.vue
+++ b/vue-app/src/components/RecipientSubmissionWidget.vue
@@ -204,7 +204,7 @@ export default class RecipientSubmissionWidget extends Vue {
       currentUser
     ) {
       try {
-        if (DateTime.now() >= currentRound.votingDeadline) {
+        if (currentRound && DateTime.now() >= currentRound.votingDeadline) {
           this.$router.push({
             name: 'join',
           })


### PR DESCRIPTION

Noticed an error in the current Arbitrum round:
![Image 2021-12-08 at 2 57 10 PM](https://user-images.githubusercontent.com/8097623/145305117-d691316f-930d-4320-b4bb-35cc11fefbf2.jpg)


Alternative fix to https://github.com/ethereum/clrfund/pull/459