### PR TITLE
Wrap behavior when copying tx hash

### DIFF
--- a/vue-app/src/components/TransactionReceipt.vue
+++ b/vue-app/src/components/TransactionReceipt.vue
@@ -17,7 +17,7 @@
     <div class="actions">
       <links
         class="explorerLink"
-        :to="blockExplorerUrl"
+        :to="blockExplorer.url"
         v-tooltip="`View on ${blockExplorer.label}`"
         :hideArrow="true"
       >

--- a/vue-app/src/views/ProjectAdded.vue
+++ b/vue-app/src/views/ProjectAdded.vue
@@ -172,10 +172,11 @@ ul {
       .flex-title {
         display: flex;
         gap: 0.5rem;
-        align-items: center;
+        align-items: left;
         margin-bottom: 3rem;
         margin-top: 1.5rem;
         flex-wrap: wrap;
+        flex-direction: column;
 
         img {
           width: 1rem;


### PR DESCRIPTION
Fixes: https://github.com/ethereum/clrfund/issues/462

**What Changed**
- Changed styling to flex column to prevent the bug of the transaction receipt going up into the title
- Fixed the blockExplorerUrl to blockExplorer.url to properly access url and link out to the transaction on the block explorer