### PR TITLE
Fix recipients list loading

### DIFF
--- a/vue-app/src/components/TransactionModal.vue
+++ b/vue-app/src/components/TransactionModal.vue
@@ -37,7 +37,7 @@ import { waitForTransaction } from '@/utils/contracts'
   },
 })
 export default class TransactionModal extends Vue {
-  @Prop() transactionFn!: () => Promise<TransactionResponse>
+  @Prop() transaction!: Promise<TransactionResponse>
   @Prop() onTxSuccess!: (txHash) => void
 
   txHash = ''
@@ -49,10 +49,7 @@ export default class TransactionModal extends Vue {
 
   private async executeTx() {
     try {
-      await waitForTransaction(
-        this.transactionFn(),
-        (hash) => (this.txHash = hash)
-      )
+      await waitForTransaction(this.transaction, (hash) => (this.txHash = hash))
 
       this.onTxSuccess(this.txHash)
     } catch (error) {

--- a/vue-app/src/views/RecipientRegistry.vue
+++ b/vue-app/src/views/RecipientRegistry.vue
@@ -269,7 +269,7 @@ export default class RecipientRegistryView extends Vue {
     this.$modal.show(
       TransactionModal,
       {
-        transactionFn: () => transaction,
+        transaction,
         onTxSuccess: async () => {
           // TODO: this is not ideal. Leaving as is, just because it is an admin
           // page where no end user is using. We are forcing this 2s time to give


### PR DESCRIPTION
Fixes #468 

When a request was approved or rejected, we were updating the list by calling the `loadRequests()` function, but we were calling it too early because we were not waiting for the tx to finish correctly.

Here, I'm fixing the TransactionModal to accept a Promise instead of a common fn, so that we can `wait()` for that tx to finish.