### PR TITLE
Get ENS avatar

### DIFF
--- a/vue-app/src/api/user.ts
+++ b/vue-app/src/api/user.ts
@@ -5,7 +5,7 @@ import { Web3Provider } from '@ethersproject/providers'
 import { UserRegistry, ERC20 } from './abi'
 import { factory, provider } from './core'
 import { BrightId } from './bright-id'
-import { get3BoxAvatarUrl } from '../utils/accounts'
+import { get3BoxAvatarUrl, getEnsAvatarUrl } from '../utils/accounts'
 
 //TODO: update anywhere this is called to take factory address as a parameter, default to env. variable
 export const LOGIN_MESSAGE = `Welcome to clr.fund!
@@ -31,6 +31,11 @@ export interface User {
 export async function getProfileImageUrl(
   walletAddress: string
 ): Promise<string | null> {
+  // Priority to ENS avatars
+  const ensAvatarUrl: string | null = await getEnsAvatarUrl(walletAddress)
+  if (ensAvatarUrl) return ensAvatarUrl
+
+  // Then to 3Box
   const threeBoxAvatarUrl: string | null = await get3BoxAvatarUrl(walletAddress)
   if (threeBoxAvatarUrl) return threeBoxAvatarUrl
 

--- a/vue-app/src/api/user.ts
+++ b/vue-app/src/api/user.ts
@@ -3,8 +3,9 @@ import { BigNumber, Contract } from 'ethers'
 import { Web3Provider } from '@ethersproject/providers'
 
 import { UserRegistry, ERC20 } from './abi'
-import { factory, ipfsGatewayUrl, provider } from './core'
+import { factory, provider } from './core'
 import { BrightId } from './bright-id'
+import { get3BoxAvatarUrl } from '../utils/accounts'
 
 //TODO: update anywhere this is called to take factory address as a parameter, default to env. variable
 export const LOGIN_MESSAGE = `Welcome to clr.fund!
@@ -30,16 +31,11 @@ export interface User {
 export async function getProfileImageUrl(
   walletAddress: string
 ): Promise<string | null> {
-  const threeBoxProfileUrl = `https://ipfs.3box.io/profile?address=${walletAddress}`
-  let profileImageHash: string
-  try {
-    const response = await fetch(threeBoxProfileUrl)
-    const profile = await response.json()
-    profileImageHash = profile.image[0].contentUrl['/']
-  } catch (error) {
-    return makeBlockie(walletAddress)
-  }
-  return `${ipfsGatewayUrl}/ipfs/${profileImageHash}`
+  const threeBoxAvatarUrl: string | null = await get3BoxAvatarUrl(walletAddress)
+  if (threeBoxAvatarUrl) return threeBoxAvatarUrl
+
+  // Blockies as a fallback
+  return makeBlockie(walletAddress)
 }
 
 export async function isVerifiedUser(

--- a/vue-app/src/utils/accounts.ts
+++ b/vue-app/src/utils/accounts.ts
@@ -1,6 +1,8 @@
 import { ethers } from 'ethers'
 import { mainnetProvider } from '@/api/core'
 import { isAddress } from '@ethersproject/address'
+import axios from 'axios'
+import { ipfsGatewayUrl } from '@/api/core'
 
 export function isSameAddress(address1: string, address2: string): boolean {
   return ethers.utils.getAddress(address1) === ethers.utils.getAddress(address2)
@@ -23,6 +25,19 @@ export async function resolveEns(name: string): Promise<string | null> {
 export async function isValidEthAddress(address: string): Promise<boolean> {
   const resolved = await mainnetProvider.resolveName(address)
   return !!resolved
+}
+
+export async function get3BoxAvatarUrl(
+  address: string
+): Promise<string | null> {
+  const threeBoxProfileUrl = `https://ipfs.3box.io/profile?address=${address}`
+  try {
+    const { data } = await axios.get(threeBoxProfileUrl)
+    const profileImageHash = data.image[0].contentUrl['/']
+    return `${ipfsGatewayUrl}/ipfs/${profileImageHash}`
+  } catch (error) {
+    return null
+  }
 }
 
 export function renderAddressOrHash(


### PR DESCRIPTION
- Extracts logic for getting account avatar to `accounts.ts` from `user.ts`, starting with `get3BoxAvatarUrl`
- Adds `getEnsAvatarUrl` function to also check if logged in user has an ENS, and if that ENS has an avatar declared. If so, fetches and loads with preference over 3Box

(Btw, ENS syntax for this is `eip155:1/[NFT standard]:[contract address for NFT collection]/[token ID or the number that it is in the collection]`)

Note, tried adding [SelfID](https://self.id/) avatar support as well, but I had some issues which I believe were related to using node v12. Worked locally, but with a bunch of console warnings related to the packages. 